### PR TITLE
fix: use match instead of is for node type checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,14 +111,13 @@ jobs:
       - name: Update VERSION file
         run: echo "${{ needs.check-changes.outputs.version }}" > VERSION
 
-      - name: Build (Debug)
-        run: v -o al_debug .
-
-      - name: Run Tests (Debug)
-        run: ./al_debug run program/src/all_language_features.al
-
       - name: Build (Production)
-        run: v -prod -o al .
+        run: |
+          if [ "${{ matrix.platform }}" = "linux" ]; then
+            v -cc gcc -cflags "-O2" -o al .
+          else
+            v -prod -o al .
+          fi
 
       - name: Run Tests
         run: ./al run program/src/all_language_features.al

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,12 @@ jobs:
       - name: Update VERSION file
         run: echo "${{ needs.check-changes.outputs.version }}" > VERSION
 
+      - name: Build (Debug)
+        run: v -o al_debug .
+
+      - name: Run Tests (Debug)
+        run: ./al_debug run program/src/all_language_features.al
+
       - name: Build (Production)
         run: v -prod -o al .
 

--- a/src/bytecode/compiler.v
+++ b/src/bytecode/compiler.v
@@ -141,26 +141,37 @@ fn (mut c Compiler) compile_statement(stmt typed_ast.Statement) ! {
 			c.current_binding = old_binding
 
 			c.emit_arg(.store_local, idx)
+			c.emit(.push_none)
 		}
 		typed_ast.ConstBinding {
 			c.compile_expr(stmt.init)!
 			idx := c.get_or_create_local(stmt.identifier.name)
 			c.emit_arg(.store_local, idx)
+			c.emit(.push_none)
 		}
 		typed_ast.TypePatternBinding {
 			c.compile_expr(stmt.init)!
 			c.emit(.pop)
+			c.emit(.push_none)
 		}
 		typed_ast.FunctionDeclaration {
 			c.compile_function_common(stmt.identifier.name, stmt.params, stmt.body)!
 			idx := c.get_or_create_local(stmt.identifier.name)
 			c.emit_arg(.store_local, idx)
+			c.emit(.push_none)
 		}
-		typed_ast.StructDeclaration {}
-		typed_ast.EnumDeclaration {}
-		typed_ast.ImportDeclaration {}
+		typed_ast.StructDeclaration {
+			c.emit(.push_none)
+		}
+		typed_ast.EnumDeclaration {
+			c.emit(.push_none)
+		}
+		typed_ast.ImportDeclaration {
+			c.emit(.push_none)
+		}
 		typed_ast.ExportDeclaration {
 			c.compile_statement(stmt.declaration)!
+			// ExportDeclaration wraps another statement which already pushes None
 		}
 	}
 }
@@ -225,16 +236,14 @@ fn (mut c Compiler) compile_expr(expr typed_ast.Expression) ! {
 					c.compile_expr(item.expression)!
 				}
 				c.in_tail_position = false
-				// only pop after expressions, not statements (statements don't push)
-				if !is_last && !item.is_statement {
+				// pop after every item except the last (statements now also push None)
+				if !is_last {
 					c.emit(.pop)
 				}
 			}
 
-			// push none if block was empty or last item was a statement
+			// push none if block was empty
 			if expr.body.len == 0 {
-				c.emit(.push_none)
-			} else if expr.body[last_idx].is_statement {
 				c.emit(.push_none)
 			}
 		}

--- a/src/bytecode/compiler.v
+++ b/src/bytecode/compiler.v
@@ -228,16 +228,22 @@ fn (mut c Compiler) compile_expr(expr typed_ast.Expression) ! {
 				c.compile_node(node)!
 				c.in_tail_position = false
 				// only pop after expressions, not statements (statements don't push)
-				if !is_last && node is typed_ast.Expression {
-					c.emit(.pop)
+				if !is_last {
+					match node {
+						typed_ast.Expression { c.emit(.pop) }
+						typed_ast.Statement {}
+					}
 				}
 			}
 
 			// push none if block was empty or last item was a statement
 			if expr.body.len == 0 {
 				c.emit(.push_none)
-			} else if expr.body[expr.body.len - 1] is typed_ast.Statement {
-				c.emit(.push_none)
+			} else {
+				match expr.body[expr.body.len - 1] {
+					typed_ast.Statement { c.emit(.push_none) }
+					typed_ast.Expression {}
+				}
 			}
 		}
 		typed_ast.NumberLiteral {

--- a/src/typed_ast/typed_ast.v
+++ b/src/typed_ast/typed_ast.v
@@ -355,4 +355,4 @@ pub type Expression = ArrayExpression
 	| UnaryExpression
 	| WildcardPattern
 
-pub type Node = Statement | Expression
+// Note: Node type removed - use BlockItem in BlockExpression instead

--- a/src/typed_ast/typed_ast.v
+++ b/src/typed_ast/typed_ast.v
@@ -284,8 +284,9 @@ pub:
 
 pub struct BlockExpression {
 pub:
-	body []Node
-	span Span @[required]
+	body              []Node
+	statement_indices []int // indices of body elements that are statements
+	span              Span @[required]
 }
 
 pub struct AssertExpression {

--- a/src/typed_ast/typed_ast.v
+++ b/src/typed_ast/typed_ast.v
@@ -282,11 +282,17 @@ pub:
 	span       Span @[required]
 }
 
+pub struct BlockItem {
+pub:
+	is_statement bool
+	statement    Statement
+	expression   Expression
+}
+
 pub struct BlockExpression {
 pub:
-	body              []Node
-	statement_indices []int // indices of body elements that are statements
-	span              Span @[required]
+	body []BlockItem
+	span Span @[required]
 }
 
 pub struct AssertExpression {

--- a/src/types/checker.v
+++ b/src/types/checker.v
@@ -326,12 +326,18 @@ fn (c TypeChecker) resolve_type_identifier(t ast.TypeIdentifier) ?Type {
 
 fn (mut c TypeChecker) check_block(block ast.BlockExpression) (typed_ast.BlockExpression, Type) {
 	mut typed_body := []typed_ast.Node{}
+	mut statement_indices := []int{}
 	mut last_type := t_none()
 
 	for i, node in block.body {
 		typed_node, typ := c.check_node(node)
 		typed_body << typed_node
 		last_type = typ
+
+		// Track which indices are statements for the compiler
+		if node is ast.Statement {
+			statement_indices << i
+		}
 
 		// For all expressions except the last one (which is the return value),
 		// check that non-None values are consumed (statements always return None)
@@ -344,8 +350,9 @@ fn (mut c TypeChecker) check_block(block ast.BlockExpression) (typed_ast.BlockEx
 	}
 
 	return typed_ast.BlockExpression{
-		body: typed_body
-		span: block.span
+		body:              typed_body
+		statement_indices: statement_indices
+		span:              block.span
 	}, last_type
 }
 


### PR DESCRIPTION
Testing if using match instead of is for nested sum types fixes the Linux segfault