### PR TITLE
carry a variant's declared name on its constructor scheme

### DIFF
--- a/crates/scarlet/build.rs
+++ b/crates/scarlet/build.rs
@@ -354,10 +354,11 @@ fn valuekind(k: ValueKind) -> String {
             type_name,
             type_id,
             variant_idx,
+            variant_name,
             arity,
             field_labels,
         } => format!(
-            "ValueKind::Constructor {{ type_name: {type_name:?}, type_id: {}, variant_idx: {variant_idx}, arity: {arity}, field_labels: {} }}",
+            "ValueKind::Constructor {{ type_name: {type_name:?}, type_id: {}, variant_idx: {variant_idx}, variant_name: {variant_name:?}, arity: {arity}, field_labels: {} }}",
             tid(type_id),
             aslice(field_labels)
         ),

--- a/crates/scarlet/tests/modules.rs
+++ b/crates/scarlet/tests/modules.rs
@@ -579,6 +579,44 @@ fn an_alias_does_not_change_a_constructed_value_identity() {
     run_project_outputs(&proj, "run", "main.scrl", "Green(9)\nTrue\nTrue\n");
 }
 
+/// An alias is free to collide with a real variant of the same type, and the
+/// collision is where a wrong name stops being a dead arm. `Green as Red`
+/// made the ladder test for `"Red"`, which `color.Red` carries: the arm was
+/// entered against a nullary variant, and binding its field 0 indexed past
+/// the end of the value stack — an interpreter panic, exit 101, after two
+/// wrong lines of output.
+///
+/// The tests above all alias to a fresh name, where the mismatch only ever
+/// costs a branch. None of them can reach this.
+#[test]
+fn an_alias_colliding_with_a_real_variant_does_not_capture_it() {
+    let proj = Project::new("alias_ctor_collide");
+    proj.write("color.scrl", COLOR_MAKE_SRC);
+    proj.write(
+        "main.scrl",
+        "import ./color\nimport ./color.{Green as Red}\n\nprintln(Red(5))\nmatch color.make(5) {\n\tRed(_s) -> println(1)\n\t_ -> println(0)\n}\nmatch color.Red {\n\tRed(_s) -> println(1)\n\t_ -> println(0)\n}\n",
+    );
+    run_project_outputs(&proj, "run", "main.scrl", "Green(5)\n1\n0\n");
+}
+
+/// A stdlib constructor's `variant_name` is written into the static blob by
+/// `crates/scarlet/build.rs`, not by the resolver, so it is a second copy of
+/// the same decision and nothing else here exercises it: all the alias tests
+/// above use user modules.
+///
+/// `binary.from_int_ascii` dispatches on its `Radix` argument by name inside
+/// the VM, so an alias-named `Hex` was a `Radix` the builtin did not
+/// recognise: `expected Radix, got 'Radix'`, exit 1.
+#[test]
+fn an_aliased_stdlib_constructor_reaches_a_vm_builtin() {
+    let proj = Project::new("alias_ctor_stdlib");
+    proj.write(
+        "main.scrl",
+        "import scarlet/binary\nimport scarlet/binary.{Hex as H}\n\nprintln(binary.from_int_ascii(255, H))\n",
+    );
+    run_project_outputs(&proj, "run", "main.scrl", "<<102, 102>>\n");
+}
+
 /// Labelled arguments and `..` work through a qualifier, as they do bare.
 #[test]
 fn a_qualified_pattern_takes_labels_and_rest() {

--- a/crates/scarlet/tests/modules.rs
+++ b/crates/scarlet/tests/modules.rs
@@ -453,6 +453,132 @@ fn an_aliased_arm_still_leaves_the_other_variant_missing() {
     project_rejects(&proj, "check", "main.scrl", &["not exhaustive", "Green"]);
 }
 
+/// `Color`, plus a constructor function in the declaring module. The four
+/// tests above all build their scrutinee in the matching file, which is the
+/// one arrangement where an alias-named value and an alias-named test agree;
+/// a value that crosses a module boundary is the ordinary case.
+const COLOR_MAKE_SRC: &str =
+    "pub type Color {\n\tRed\n\tGreen(shade Int)\n}\n\npub fn make(n Int) Color {\n\tGreen(n)\n}\n";
+
+/// Three variants, so a catch-all arm stays reachable alongside an arm that
+/// covers only one of them.
+const HUE_SRC: &str = "pub type Hue {\n\tRed\n\tGreen(shade Int)\n\tBlue\n}\n\npub fn make(n Int) Hue {\n\tGreen(n)\n}\n";
+
+/// A match with a catch-all arm is not exhaustive-by-heads, so it lowers to
+/// the test ladder rather than the tag switch. The ladder compared the
+/// scrutinee against the variant name *as the pattern spelled it*, so an
+/// aliased head tested for a name no value ever carries: the arm was dead and
+/// control fell to the catch-all, silently.
+///
+/// The four tests above omit a catch-all, so all four take the switch and
+/// none of them can see this.
+#[test]
+fn an_aliased_arm_matches_beside_a_catch_all() {
+    let proj = Project::new("alias_ctor_catchall");
+    proj.write("color.scrl", COLOR_MAKE_SRC);
+    proj.write(
+        "main.scrl",
+        "import ./color\nimport ./color.{Green as G}\n\nx = color.make(9)\nmatch x {\n\tG(s) -> println(s)\n\t_ -> println(0)\n}\n",
+    );
+    run_project_outputs(&proj, "run", "main.scrl", "9\n");
+}
+
+/// A bare binding arm is a catch-all too, and takes the same ladder. This is
+/// the shape that broke RESP3 pub/sub: `other -> ...` after an aliased head.
+#[test]
+fn an_aliased_arm_matches_beside_a_bare_binding_catch_all() {
+    let proj = Project::new("alias_ctor_binding_catchall");
+    proj.write("color.scrl", COLOR_MAKE_SRC);
+    proj.write(
+        "main.scrl",
+        "import ./color\nimport ./color.{Green as G}\n\nx = color.make(7)\nmatch x {\n\tG(s) -> println(s)\n\tother -> println(other)\n}\n",
+    );
+    run_project_outputs(&proj, "run", "main.scrl", "7\n");
+}
+
+/// The same match, with the scrutinee built through the qualifier in this
+/// file rather than returned from the module.
+#[test]
+fn an_aliased_arm_matches_a_qualified_scrutinee_beside_a_catch_all() {
+    let proj = Project::new("alias_ctor_qual_catchall");
+    proj.write("color.scrl", COLOR_MAKE_SRC);
+    proj.write(
+        "main.scrl",
+        "import ./color\nimport ./color.{Green as G}\n\nx = color.Green(4)\nmatch x {\n\tG(s) -> println(s)\n\t_ -> println(0)\n}\n",
+    );
+    run_project_outputs(&proj, "run", "main.scrl", "4\n");
+}
+
+/// An aliased head nested inside a tuple pattern reaches the ladder through a
+/// different lowering path than a top-level head, and resolved the same way.
+#[test]
+fn an_aliased_head_matches_nested_beside_a_catch_all() {
+    let proj = Project::new("alias_ctor_nested_catchall");
+    proj.write("hue.scrl", HUE_SRC);
+    proj.write(
+        "main.scrl",
+        "import ./hue\nimport ./hue.{Green as G}\n\nn = (hue.make(9), 1)\nmatch n {\n\t(G(s), 1) -> println(s)\n\t_ -> println(0)\n}\n",
+    );
+    run_project_outputs(&proj, "run", "main.scrl", "9\n");
+}
+
+/// An aliased head as one alternative of an or-pattern. `Hue`'s third variant
+/// keeps the catch-all reachable, so the match still takes the ladder.
+#[test]
+fn an_aliased_head_matches_in_an_or_pattern_beside_a_catch_all() {
+    let proj = Project::new("alias_ctor_or_catchall");
+    proj.write("hue.scrl", HUE_SRC);
+    proj.write(
+        "main.scrl",
+        "import ./hue\nimport ./hue.{Green as G}\n\no = hue.make(4)\nmatch o {\n\tG(_s) | hue.Red -> println(1)\n\t_ -> println(0)\n}\n",
+    );
+    run_project_outputs(&proj, "run", "main.scrl", "1\n");
+}
+
+/// As `an_aliased_constructor_destructures_irrefutably`, but the value comes
+/// from the declaring module rather than being built through the alias here.
+#[test]
+fn an_aliased_destructure_takes_a_value_from_the_declaring_module() {
+    let proj = Project::new("alias_ctor_destructure_cross");
+    proj.write(
+        "pair.scrl",
+        "pub type Pair {\n\tPair(a Int, b Int)\n}\n\npub fn make(x Int, y Int) Pair {\n\tPair(x, y)\n}\n",
+    );
+    proj.write(
+        "main.scrl",
+        "import ./pair\nimport ./pair.{Pair as P}\n\nP(a, b) = pair.make(1, 2)\nprintln(a + b)\n",
+    );
+    run_project_outputs(&proj, "run", "main.scrl", "3\n");
+}
+
+/// Resolving the head through the declaration must not make a dead arm look
+/// live: a catch-all placed first still shadows the aliased arm after it.
+#[test]
+fn a_catch_all_before_an_aliased_arm_is_still_unreachable() {
+    let proj = Project::new("alias_ctor_catchall_first");
+    proj.write("hue.scrl", HUE_SRC);
+    proj.write(
+        "main.scrl",
+        "import ./hue\nimport ./hue.{Green as G}\n\nc = hue.make(3)\nmatch c {\n\t_ -> println(0)\n\tG(_s) -> println(1)\n}\n",
+    );
+    project_rejects(&proj, "check", "main.scrl", &["unreachable"]);
+}
+
+/// The alias is a spelling, not an identity. A value built through it is the
+/// variant the module declares: it prints under that name and is equal to the
+/// same variant built any other way. Carrying the written name onto the value
+/// made `G(9) == color.Green(9)` false and printed `G(9)`.
+#[test]
+fn an_alias_does_not_change_a_constructed_value_identity() {
+    let proj = Project::new("alias_ctor_value_identity");
+    proj.write("color.scrl", COLOR_MAKE_SRC);
+    proj.write(
+        "main.scrl",
+        "import ./color\nimport ./color.{Green as G}\n\nprintln(G(9))\nprintln(G(9) == color.Green(9))\nprintln(G(9) == color.make(9))\n",
+    );
+    run_project_outputs(&proj, "run", "main.scrl", "Green(9)\nTrue\nTrue\n");
+}
+
 /// Labelled arguments and `..` work through a qualifier, as they do bare.
 #[test]
 fn a_qualified_pattern_takes_labels_and_rest() {

--- a/crates/scarlet/tests/native_backend.rs
+++ b/crates/scarlet/tests/native_backend.rs
@@ -193,6 +193,58 @@ println(spin(3000000, 0))
     );
 }
 
+/// An aliased constructor's match arm, run hot. The alias tests in
+/// `modules.rs` all run cold, and cold is the one configuration where the two
+/// engines cannot be seen to disagree: with the ladder testing the name as
+/// the arm spelled it, the interpreted iterations fell to the catch-all and
+/// the compiled ones did not, so one program returned two answers inside one
+/// process, with no error on either stream.
+///
+/// `hit` is a separate body so it warms on call count, and 20,000 iterations
+/// put both sides of the threshold in the sum: 20,000 is reachable only if
+/// every iteration took the aliased arm, whichever engine ran it. The debug
+/// line is the witness that the compile fired at all — without it a green
+/// result could mean the body never left the interpreter.
+#[test]
+fn a_warmed_aliased_match_agrees_across_the_warmup_boundary() {
+    let src = "import ./color
+import ./color.{Color, Green as G}
+
+fn hit(c Color) Int {
+	match c {
+		G(_s) -> 1
+		_ -> 0
+	}
+}
+
+fn drive(i Int, acc Int) Int {
+	if i == 0 { acc } else { drive(i - 1, acc + hit(color.make(i))) }
+}
+
+println(drive(20000, 0))
+";
+    let proj = Project::new("alias_warm");
+    proj.write(
+        "color.scrl",
+        "pub type Color {\n\tRed\n\tGreen(shade Int)\n}\n\npub fn make(n Int) Color {\n\tGreen(n)\n}\n",
+    );
+    let path = proj.dir.join("prog.scrl");
+    std::fs::write(&path, src).unwrap();
+    let path = path.to_string_lossy().into_owned();
+    let out = run_al_env(&["run", &path], &[("SCARLET_NATIVE_DEBUG", "1")]);
+    assert!(out.success, "run failed:\n{}", out.stderr);
+    assert_eq!(
+        out.stdout, "20000\n",
+        "an aliased arm must match under both engines; stderr:\n{}",
+        out.stderr
+    );
+    assert!(
+        out.stderr.contains("warmed fn"),
+        "the match must be compiled, or this only tests the interpreter; stderr:\n{}",
+        out.stderr
+    );
+}
+
 /// (d) Int overflow spill past ±2^47, where Ints leave the NaN-box payload,
 /// and at the i64 wrap. The recursion warms both functions mid-run, so the
 /// pinned literals hold across the interp→native switch.

--- a/crates/scarlet_core/src/bytecode/analysis.rs
+++ b/crates/scarlet_core/src/bytecode/analysis.rs
@@ -881,8 +881,13 @@ impl Compiler {
                 }
 
                 let fields = c.engine.push_variant_fields(&field_defs);
+                // One interned name for the variant, shared by the type's
+                // variant table and the constructor's own scheme, so a use
+                // site never has to re-derive it from the name it was bound
+                // under — which an alias changes.
+                let variant_name = c.engine.intern(&ctor.identifier.name);
                 variants.push(Variant {
-                    name: c.engine.intern(&ctor.identifier.name),
+                    name: variant_name,
                     fields,
                 });
                 let field_labels = c.engine.push_str_ids(&label_ids);
@@ -898,6 +903,7 @@ impl Compiler {
                     type_name: type_name_id,
                     type_id,
                     variant_idx,
+                    variant_name,
                     arity: ctor.fields.len() as u16,
                     field_labels,
                 };

--- a/crates/scarlet_core/src/bytecode/compiler/bridges.rs
+++ b/crates/scarlet_core/src/bytecode/compiler/bridges.rs
@@ -130,7 +130,7 @@ impl ElabCtx for Compiler {
         // Called even for constructors and builtins, for its side effects:
         // marking the name used, and recording a capture.
         let place = self.resolve_variable(id);
-        let den = match (Denotation::from_kind(kind, id), place) {
+        let den = match (Denotation::from_kind(kind), place) {
             (Some(fixed), _) => fixed,
             (None, Some(place)) => place,
             // `analyse_module` unwinds `self.locals` before `__main__`
@@ -159,10 +159,9 @@ impl ElabCtx for Compiler {
         let scheme = ev.scheme;
         let ty = self.engine.instantiate(&scheme, &self.rigid_ids);
         let local_slot = ev.local_slot;
-        let sid = self.engine.intern(member);
         // `@vm` builtins and re-exported constructors carry no `local_slot`;
         // their `ValueKind` alone denotes them. Everything else must have one.
-        let den = match Denotation::from_kind(scheme.kind, sid) {
+        let den = match Denotation::from_kind(scheme.kind) {
             Some(fixed) => fixed,
             None => match local_slot {
                 Some(slot) => self.global_denotation(slot),

--- a/crates/scarlet_core/src/bytecode/prelude_bindings.rs
+++ b/crates/scarlet_core/src/bytecode/prelude_bindings.rs
@@ -354,6 +354,7 @@ mod tests {
                     type_name: StrId(0),
                     type_id,
                     variant_idx: 0,
+                    variant_name: StrId(0),
                     arity,
                     field_labels: ArenaSlice::EMPTY,
                 },

--- a/crates/scarlet_core/src/typed_ir/resolve.rs
+++ b/crates/scarlet_core/src/typed_ir/resolve.rs
@@ -16,7 +16,7 @@
 
 use crate::bytecode::Op;
 use crate::core_ir::{FuncIdx, VariantRef};
-use crate::types::{StrId, ValueKind};
+use crate::types::ValueKind;
 
 use super::{Arity, CaptureIdx, FrameSlot, GlobalSlot, RTy, TypedCallee, TypedExpr, ValueRef};
 
@@ -136,12 +136,19 @@ impl Denotation {
     /// `None` for [`ValueKind::Local`] / [`ValueKind::ModuleFn`], which denote
     /// a *place* only the binding frame knows. Taking no place parameter is
     /// what stops a constructor's frame resolution leaking into a [`ValueRef`].
-    pub(crate) fn from_kind(kind: ValueKind, name: StrId) -> Option<Self> {
+    ///
+    /// Takes no name either, for the same reason: every field of the
+    /// [`VariantRef`] is the declaration's, so the name a use site spelled the
+    /// constructor with cannot reach codegen. It used to be the one field read
+    /// off the binding, which is how an aliased import put `G` where `Green`
+    /// belonged.
+    pub(crate) fn from_kind(kind: ValueKind) -> Option<Self> {
         match kind {
             ValueKind::Constructor {
                 type_id,
                 variant_idx,
                 type_name,
+                variant_name,
                 arity,
                 ..
             } => Some(Denotation::ctor(
@@ -149,7 +156,7 @@ impl Denotation {
                     type_id,
                     variant_idx,
                     type_name,
-                    variant_name: name,
+                    variant_name,
                 },
                 Arity(arity),
             )),
@@ -205,6 +212,7 @@ impl Denotation {
 mod tests {
     use super::*;
     use crate::type_def::TypeId;
+    use crate::types::StrId;
 
     const TY: RTy = RTy(7);
 
@@ -234,8 +242,8 @@ mod tests {
     /// the frame that bound it knows where it lives.
     #[test]
     fn the_kind_bridge_defers_places_to_the_frame() {
-        assert_eq!(Denotation::from_kind(ValueKind::ModuleFn, StrId(0)), None);
-        assert_eq!(Denotation::from_kind(ValueKind::Local, StrId(0)), None);
+        assert_eq!(Denotation::from_kind(ValueKind::ModuleFn), None);
+        assert_eq!(Denotation::from_kind(ValueKind::Local), None);
     }
 
     /// A nested lambda's frame is a real closure frame, so `PushSelf` is right.
@@ -327,18 +335,21 @@ mod tests {
 
     /// A constructor's frame resolution is meaningless and must not leak into
     /// a `ValueRef`. `from_kind` takes no place at all, so it cannot.
+    ///
+    /// It takes no name either, so the `VariantRef` it builds is the
+    /// declaration's in every field. The name a use site bound the constructor
+    /// under used to be passed in alongside, and an aliased import made that
+    /// the alias.
     #[test]
     fn a_ctors_meaningless_frame_resolution_cannot_leak() {
-        let d = Denotation::from_kind(
-            ValueKind::Constructor {
-                type_name: StrId(10),
-                type_id: TypeId(3),
-                variant_idx: 1,
-                arity: 0,
-                field_labels: crate::types::ArenaSlice::EMPTY,
-            },
-            StrId(11),
-        )
+        let d = Denotation::from_kind(ValueKind::Constructor {
+            type_name: StrId(10),
+            type_id: TypeId(3),
+            variant_idx: 1,
+            variant_name: StrId(11),
+            arity: 0,
+            field_labels: crate::types::ArenaSlice::EMPTY,
+        })
         .expect("a constructor's kind fixes its denotation");
         assert_eq!(d.as_value(), ValueForm::Ctor(variant()));
         assert_eq!(d.as_ctor(), Some((variant(), Arity(0))));
@@ -347,7 +358,7 @@ mod tests {
     /// A builtin's kind fixes it too, and it is not a constructor.
     #[test]
     fn a_builtins_kind_fixes_its_denotation() {
-        let d = Denotation::from_kind(ValueKind::Builtin { op: Op::Add }, StrId(0))
+        let d = Denotation::from_kind(ValueKind::Builtin { op: Op::Add })
             .expect("a builtin's kind fixes its denotation");
         assert_eq!(d, Denotation::builtin(Op::Add));
         assert_eq!(d.as_ctor(), None);

--- a/crates/scarlet_types/src/types/infer.rs
+++ b/crates/scarlet_types/src/types/infer.rs
@@ -268,6 +268,12 @@ pub enum ValueKind {
         type_name: StrId,
         type_id: TypeId,
         variant_idx: u16,
+        /// The name the *declaration* gives this variant, never the name a use
+        /// site spelled it with. An aliased import (`{Green as G}`) binds this
+        /// scheme under `G`, and a constructed value and a pattern test both
+        /// carry a variant name into codegen; taking it from the binding made
+        /// the two disagree whenever only one of them went through the alias.
+        variant_name: StrId,
         arity: u16,
         /// → `InferEngine.str_slices`
         field_labels: ArenaSlice<pool::StrSlices>,


### PR DESCRIPTION
An aliased constructor import (`import ./color.{Green as G}`) never matched when the match also had a catch-all arm. No error, no warning — the arm was dead and control took the wrong branch. It shipped, and it broke RESP3 pub/sub in the redis client.

## It is a value-identity bug, not a matching bug

The ticket framed this as patterns failing to match. The cause is wider:

```
println(G(9))                     was  G(9)     now  Green(9)
println(G(9) == color.Green(9))   was  False    now  True
```

**Two values of the same variant with the same payload compared unequal** because one was built through an alias.

## Root cause

`resolve.rs`'s `from_kind` built a `VariantRef` taking three fields from the declaration and `variant_name` from **the binding** — which an aliased import makes `G`. `ValueKind::Constructor` never carried the declared variant name, despite a comment claiming it "carries enough to compile pattern-match and constructor-call".

The catch-all only decides *which consumer notices*. `emit_ladder` tests `Op::MatchEnum` against the name **string**; `emit_switch`, taken when the match is exhaustive by heads, dispatches on the tag and is immune. Confirmed in the disassembly: `MatchEnum` against `PushConst "G"` while the value carried `Green`.

**Fix:** `ValueKind::Constructor` carries `variant_name` from the declaration, and `from_kind` **takes no name parameter at all**, so a use site's spelling cannot reach codegen.

## Why the previous fix missed it

All four tests in `9999018` build their scrutinee **in the matching file** and omit a catch-all. Both halves mattered, and the second is the one nobody spotted: a value built through the alias carried the *alias* name, so an alias-named test matched it by accident. **The four tests were self-consistent in exactly the way real code is not.**

## The failing tests came first

Eight tests written against pristine `d49ebb8` before any compiler change:

```
test result: FAILED. 9 passed; 6 failed
an_aliased_arm_matches_beside_a_catch_all ... FAILED
an_aliased_arm_matches_beside_a_bare_binding_catch_all ... FAILED
an_aliased_arm_matches_a_qualified_scrutinee_beside_a_catch_all ... FAILED
an_aliased_head_matches_nested_beside_a_catch_all ... FAILED
an_aliased_head_matches_in_an_or_pattern_beside_a_catch_all ... FAILED
an_alias_does_not_change_a_constructed_value_identity ... FAILED
```

Reverting only the six compiler files afterwards, keeping the tests, reproduces the same six.

## Neighbouring shapes

| shape | before | after |
|---|---|---|
| nested, in a tuple, + catch-all | fell through | fixed |
| or-pattern + catch-all | fell through | fixed |
| bare binding `other ->` | fell through | fixed |
| `let` destructure, value from declaring module | correct | correct |
| catch-all **before** the aliased arm | rejected unreachable | rejected |

The last two were already correct and act as guards against the fix rather than reproductions. The destructure survived because an irrefutable single-variant unwrap emits no name test.

## Gates

`fmt` 0, `clippy` 0, `test` 0 — 41 `test result: ok`, zero failures. `SCARLET_GC_STRESS=1` likewise 0. `dylint` 0.

**`cargo hawk check -D warnings` is UNRUN, not passed** — `error: no such command: hawk`. It is a CI gate and this host does not have it.

## Filed, not fixed

- `emit_ladder` identifies variants by name string while `emit_switch` uses the tag. The source now makes all sites agree; their *ability* to disagree is untouched, and the same name-based sites exist in the JIT. Hot path, wants its own measurement.
- The docs say selective imports pull "types, constants, and functions". Constructors are missing from that list. Pre-existing.

This does not close the two open `check_parity` jump-over tickets — it touches pattern head resolution, not jump patching. `check_parity` passes.
