### PR TITLE
patch an eta wrapper's jump-over past the whole deferral region

### DIFF
--- a/crates/scarlet/tests/check_parity.rs
+++ b/crates/scarlet/tests/check_parity.rs
@@ -236,6 +236,76 @@ println(outer(4))
     assert_no_jump_into_a_foreign_body(&built);
 }
 
+/// Compile `source` against the stdlib and hand back the emitted program.
+fn layout_of(source: &str) -> scarlet::bytecode::Program {
+    let ast = parse(source);
+    let built = scarlet::bytecode::compile(&ast, None, Some(&scarlet::STDLIB));
+    assert!(
+        built.success(),
+        "compile failed:\n{source}\n{:#?}",
+        built.diagnostics
+    );
+    built.into_runnable().expect("compile emits").program
+}
+
+/// A constructor named without being called is eta-expanded into a wrapper
+/// function, and a wrapper minted for a *function body* is written inside the
+/// deferral region, immediately ahead of the body that named it. Its jump-over
+/// therefore has the whole rest of the region behind it, not just its own
+/// `Ret`: patched to its own end it lands on `wrap`'s first instruction.
+#[test]
+fn an_eta_wrapper_in_a_body_clears_the_whole_region() {
+    assert_no_jump_into_a_foreign_body(&layout_of(
+        r#"import scarlet/array
+type W { W(v Int) }
+fn wrap(xs) {
+	array.map(xs, W)
+}
+println(array.length(wrap([1, 2, 3])))
+"#,
+    ));
+}
+
+/// The same shape reached through a `@vm` builtin as a value. It is one bug,
+/// not two: `ValueKind::Builtin` and `ValueKind::Constructor` both eta-expand,
+/// and it is where the wrapper is written — inside the region — that decides
+/// the jump-over's target.
+#[test]
+fn an_eta_wrapper_over_a_builtin_clears_the_whole_region() {
+    assert_no_jump_into_a_foreign_body(&layout_of(
+        r#"import scarlet/array
+import scarlet/string
+fn lens(xs) {
+	array.map(xs, string.length)
+}
+println(array.length(lens(['ab', 'cde'])))
+"#,
+    ));
+}
+
+/// The other splice, which the region patch must leave alone: a wrapper the
+/// *toplevel* named is written after the region has drained, ahead of the
+/// toplevel init, so "just past my own `Ret`" names the next wrapper's jump-over
+/// or the init — never a body. That is the `None` arm, and this pins it.
+///
+/// It does not witness the jump being *taken*, and neither do the two above: no
+/// jump-over in either splice is reachable, because `append_toplevel_init`
+/// overwrites the head of the region with a `Jump` to the init. What all three
+/// pin is the layout.
+#[test]
+fn an_eta_wrapper_at_the_toplevel_is_spliced_past_every_body() {
+    assert_no_jump_into_a_foreign_body(&layout_of(
+        r#"import scarlet/array
+type W { W(v Int) }
+fn ident(n) {
+	n
+}
+ws = array.map([1, 2, 3], W)
+println(array.length(ws) + ident(1))
+"#,
+    ));
+}
+
 /// The entry point is the last function either mode registers.
 #[test]
 fn check_and_compile_agree_on_the_entry_index() {

--- a/crates/scarlet/tests/vm_exec.rs
+++ b/crates/scarlet/tests/vm_exec.rs
@@ -1067,4 +1067,36 @@ run_case! {
          each([1, 2], println)\n",
         "1\n2\n",
     ),
+    // The three above name the value at the *toplevel*; these two name it inside
+    // a function body, where the wrapper is written into the deferral region
+    // instead. That is new coverage of the shape — eta-expanding a builtin and a
+    // constructor reached through a body, and calling the result.
+    //
+    // It is not a witness for the jump-over mispatch `tests/check_parity.rs`
+    // pins: both cases pass against the unfixed compiler, because the mispatched
+    // jump is never executed. Only the layout assertion catches that.
+    builtin_as_a_value_inside_a_function_body: (
+        "import scarlet/array\n\
+         import scarlet/string\n\
+         fn lens(xs Array(String)) Array(Int) {\n\
+         \tarray.map(xs, string.length)\n\
+         }\n\
+         println(lens(['a', 'bb', 'ccc']))\n",
+        "[1, 2, 3]\n",
+    ),
+    ctor_as_a_value_inside_a_function_body: (
+        "import scarlet/array\n\
+         type W { W(v Int) }\n\
+         fn wrap(xs Array(Int)) Array(W) {\n\
+         \tarray.map(xs, W)\n\
+         }\n\
+         fn total(ws Array(W)) Int {\n\
+         \tarray.fold(ws, 0, fn(a, w) match w {\n\
+         \t\tW(v) -> a + v\n\
+         \t})\n\
+         }\n\
+         println(array.length(wrap([1, 2, 3])))\n\
+         println(total(wrap([4, 5, 6])))\n",
+        "3\n15\n",
+    ),
 }

--- a/crates/scarlet_core/src/bytecode/compiler/mod.rs
+++ b/crates/scarlet_core/src/bytecode/compiler/mod.rs
@@ -667,6 +667,23 @@ pub struct Compiler {
     /// constructor or sibling decl (`println = 5` after `fn g() { println(x) }`
     /// turned the callee into a self-call).
     deferred_env_pin: Option<(usize, TypeEnv)>,
+    /// Jump-overs emitted by [`Self::materialize_eta_wrappers`] *while a
+    /// deferral region is draining*, collected for the region-wide patch at
+    /// the end of [`Self::end_deferred_elaboration`].
+    ///
+    /// `Some` for exactly the span of that drain, and that is the whole point:
+    /// what a wrapper's jump-over may target is decided by what was emitted
+    /// after it, and only the drain knows. Outside a drain the wrappers are the
+    /// last thing before the toplevel init, so "just past my own `Ret`" names
+    /// the next wrapper's jump-over or the init itself — neither inside a
+    /// function body. Inside a drain it names the next *body*'s `code_start`,
+    /// which is a jump into a foreign frame's code.
+    ///
+    /// The invariant is a layout one, not a control-flow one: no jump-over in
+    /// either splice is ever executed, because `append_toplevel_init` overwrites
+    /// the head of the region with a `Jump` to the init and control reaches a
+    /// body only by `CallKnown`.
+    region_jump_overs: Option<Vec<i32>>,
     /// Native-backend hook, installed by [`compile_with_native`] and fired by
     /// `elaborate_body` / `materialize_eta_wrappers` once per lowered body —
     /// see [`NativeHook`]. `None` on every other path (plain compile/check,
@@ -833,6 +850,31 @@ fn unclaimed_toplevel_slots(n: usize) -> ! {
 fn function_reserved_during_elaboration() -> ! {
     panic!(
         "internal compiler error: a `Function` was reserved while the elaborator walked. \
+         Report this as a compiler bug."
+    )
+}
+
+/// The deferral drain opened a jump-over collector and it was gone by the end
+/// of the same call, so something re-entered `end_deferred_elaboration`.
+///
+/// A detector, not a preventer, and the difference is worth knowing before
+/// trusting it: a re-entrant drain replaces the outer collector on the way in,
+/// dropping the jump-overs already in it, and its own `take()` leaves `None`
+/// behind — so every wrapper materialized between that point and here takes the
+/// `None` arm, with the mispatch [`Compiler::region_jump_overs`] exists to stop.
+/// By the time this fires the region is already laid down. Aborting is what is
+/// left, and it happens in release too; in debug the `debug_assert` in
+/// `end_deferred_elaboration` fires first.
+///
+/// Nothing nests today: `begin_deferred_elaboration` has three callers
+/// (`analyse_module` and the two bare-expression entries) and none of them runs
+/// from inside a drained body.
+#[allow(clippy::panic)]
+#[cold]
+#[inline(never)]
+fn region_collector_lost() -> ! {
+    panic!(
+        "internal compiler error: the deferral drain's jump-over collector went missing. \
          Report this as a compiler bug."
     )
 }
@@ -1187,6 +1229,7 @@ pub(crate) fn new_compiler(base_dir: Option<&Path>, check_only: bool) -> Compile
         deferred_bodies: Vec::new(),
         defer_depth: 0,
         deferred_env_pin: None,
+        region_jump_overs: None,
         native_hook: None,
         native_stats: super::native::UnitStats::default(),
         frame_layouts: std::collections::HashMap::new(),
@@ -4492,9 +4535,10 @@ impl Compiler {
     /// its own body, and `base` becomes the body's `Function.code_start`, which
     /// the VM adds to every frame-relative jump operand `emit` produced. So
     /// `base` must name the body's first instruction. Each wrapper is
-    /// self-contained — a `Jump` over its own body, then the body — so the
-    /// surrounding stream falls straight through it. The elaborator itself
-    /// cannot touch `program.code`; the debug assertion below pins that.
+    /// self-contained — a `Jump` over its own body, then the body — so it can be
+    /// spliced into a stream without disturbing it. Where that `Jump` points is
+    /// [`Self::materialize_eta_wrappers`]'s call, not this one's. The elaborator
+    /// itself cannot touch `program.code`; the debug assertion below pins that.
     fn elaborate_then_materialize(
         &mut self,
         _clean: CleanModule,
@@ -4609,6 +4653,13 @@ impl Compiler {
     ///
     /// They go down ahead of the body that named them, each behind a `Jump`
     /// over itself, exactly where the old request-and-synthesise path put them.
+    ///
+    /// Where that `Jump` may point is not a local question. Ahead of a toplevel
+    /// init the wrappers are the last thing emitted, so clearing its own body
+    /// lands it outside every body; emitted inside a deferral drain the code
+    /// after it is the next *body*, so it must clear the whole region and only
+    /// the drain knows where that ends — [`Self::region_jump_overs`] is how it
+    /// says so, and patches them.
     fn materialize_eta_wrappers(
         &mut self,
         pool: &ResolvedPool,
@@ -4641,7 +4692,14 @@ impl Compiler {
             self.program.code.extend(out.code);
             self.emit(Op::Ret);
             let end = self.current_addr();
-            self.program.code[jump_over as usize].operand = end;
+            match self.region_jump_overs.as_mut() {
+                // A drain is running, so `end` is the next body's `code_start`,
+                // not the tail of the splice: patching here would aim this jump
+                // at a foreign frame's first instruction. The drain patches it
+                // past the whole region instead.
+                Some(region) => region.push(jump_over),
+                None => self.program.code[jump_over as usize].operand = end,
+            }
             let f = &mut self.program.functions[base + i];
             f.locals = f.arity.max(out.locals);
             f.code_start = body_start;
@@ -4806,7 +4864,16 @@ impl Compiler {
             return;
         }
         let bodies = std::mem::take(&mut self.deferred_bodies);
-        let jumps: Vec<i32> = bodies.iter().map(|d| d.jump_over).collect();
+        let mut jumps: Vec<i32> = bodies.iter().map(|d| d.jump_over).collect();
+        // Open the collector for the eta-wrapper jump-overs the bodies below
+        // will emit. It is `Some` for exactly this drain, which is what tells
+        // `materialize_eta_wrappers` that what follows a wrapper is another
+        // body rather than the tail of the splice.
+        debug_assert!(
+            self.region_jump_overs.is_none(),
+            "a deferral drain is already collecting jump-overs"
+        );
+        self.region_jump_overs = Some(Vec::new());
         // Bodies parked before `pin_deferred_env` (the declaration walk's)
         // elaborate against the env that walk saw; the rest (lambdas the
         // toplevel `let` walk parked) against the live one. See the pin's docs.
@@ -4837,6 +4904,13 @@ impl Compiler {
         if let Some(live) = live_env {
             self.env = live;
         }
+        // The wrappers written between the bodies clear the region on the same
+        // terms as the bodies' own jump-overs: everything the drain emitted is
+        // behind `end`.
+        let Some(region) = self.region_jump_overs.take() else {
+            region_collector_lost()
+        };
+        jumps.extend(region);
         let end = self.current_addr();
         for j in jumps {
             self.program.code[j as usize].operand = end;


### PR DESCRIPTION
`check_parity`'s `jump_overs_skip_every_body_parked_beside_them` failed for two apparently different shapes, reported separately. They are one bug, and it is neither of the two suspects the tickets named.

## Not backpassing, and not the builtin

Two-line repros with no backpassing anywhere both fail on pristine master:

```
fn wrap(xs) { array.map(xs, W) }              -> FAILS
fn lens(xs) { array.map(xs, string.length) }  -> FAILS
ws = array.map([1, 2, 3], W)   (at toplevel)  -> passes
```

`ValueKind::Constructor` and `ValueKind::Builtin` both eta-expand. **What decides it is where the wrapper is written.** `materialize_eta_wrappers` patched each wrapper's jump-over to just past its own `Ret`. Spliced ahead of a toplevel init that is correct — the next instruction is runnable code. Inside a deferral drain the next instruction is the *next body*, so the jump aimed at a foreign frame's first instruction.

The drain now opens a collector; wrappers register there and are patched past the whole region alongside the bodies' own jump-overs.

## It does not miscompile at runtime

Measured, not argued. Replacing the mispatched `Jump` with `Op::Halt` — which stops the VM dead — and running the program gives the same answer, `42`. **The instruction is never executed.**

The reason is structural: control enters a module's region only at its head, which `append_toplevel_init` overwrites with `Jump base` past everything, so every jump-over in a region is dead code.

Two corroborations, both accidental and both worth more than the intended ones: leaving the *toplevel* wrapper's jump-over entirely unpatched broke nothing in `vm_exec` (51 passed), and `--test stdlib` is 14/14 green on both branches **with the violation present**.

**So the invariant is violated and the machine is unaffected.** This is a structural fix, not an urgent one.

## The check watched failing

Two new tests in `crates/scarlet/tests/check_parity.rs`, with the fix reverted:

```
an_eta_wrapper_over_a_builtin_clears_the_whole_region ... FAILED
an_eta_wrapper_in_a_body_clears_the_whole_region ... FAILED
Jump at 10034 targets 10039 — inside function 223 (lens), whose body is [10039, 10047)
Jump at 10034 targets 10043 — inside function 223 (wrap), whose body is [10043, 10051)
```

A third new test — the toplevel companion — stays green in both states, which is what makes the pair discriminating rather than merely red.

Both original triggers reproduced byte for byte in throwaway worktrees and then fixed:

- the TLS branch with its backpassing `connect` restored: `Jump at 9797 targets 9806 — inside function 214 (connect), whose body is [9806, 9824)`
- the JSON branch with its four `scalar` sites reverted: `Jump at 10810 targets 10815 — inside function 241 (string_value), whose body is [10815, 10820)`

With this fix cherry-picked, each is `check_parity` 9/9 and `stdlib` 14/14.

**Honest limit:** the two `vm_exec` runtime cases added here do **not** go red before the fix. They exercise the wrapper's body, not its jump-over, and the jump-over is dead. They are coverage for a shape that had none — all three existing eta run-cases name the value at the toplevel — not a regression test for this bug.

## Gates

`cargo test` whole workspace **rc=0**, 41 test binaries, 0 failures. `cargo clippy --all-targets` **rc=0** — the first run was rc=101 because `clippy::expect_used` is denied in `scarlet_core`; replaced with the crate's existing cold-ICE idiom, matching `function_reserved_during_elaboration`. `cargo fmt` clean.

## Sequencing note for whoever merges the stdlib branches

The TLS and JSON branches each carry a workaround for this bug, and both name reverting it in their DONE-WHEN. **Those reverts cannot land here** — the files are on unmerged branches, not master. Both reverts were applied and tested in throwaway worktrees, so the edits are known-good; each has to go on whichever branch lands after this one.

## Filed, not fixed

`Function.code_len` excludes the `Ret` in `elaborate_body` (`end - base - 1`) and includes it in `materialize_eta_wrappers` (`end - body_start`). `check_parity` builds its body ranges from that pair, so a jump onto a declared body's final `Ret` reads as outside the body — a one-instruction hole in the guard. Read, not verified, and kept out of this diff.

## Documentation

None owed, checked rather than assumed: the website docs mention neither the workaround nor jump/deferral/lambda layout. Nothing user-visible changed — the builtin-as-value form already type-checked and ran correctly; only the emitted layout moved.
