### PR TITLE
drop the T-129/T-135 eta workarounds

### DIFF
--- a/crates/scarlet_core/src/std/scarlet/json/decode.scrl
+++ b/crates/scarlet_core/src/std/scarlet/json/decode.scrl
@@ -114,12 +114,6 @@ pub fn fail(expected String) Decoder(a) {
 	Decoder(fn(path, doc) Err(one_failure(path, expected, doc)))
 }
 
-// The `read` argument is passed as an explicit lambda at every call site
-// below rather than as the bare builtin. That is a workaround for T-135:
-// a `@vm` builtin used as a first-class value eta-expands into a wrapper
-// whose deferral-region jump-over is patched to the wrong target, which
-// `check_parity`'s `jump_overs_skip_every_body_parked_beside_them` catches.
-// The extra closure is built once per decoder, not once per field.
 fn scalar(expected String, read fn(json.Doc) Option(a)) Decoder(a) {
 	Decoder(fn(path, doc) match read(doc) {
 		Some(v) -> Ok(v)
@@ -128,21 +122,21 @@ fn scalar(expected String, read fn(json.Doc) Option(a)) Decoder(a) {
 }
 
 pub fn string_value() Decoder(String) {
-	scalar('a string', fn(d) json.string(d))
+	scalar('a string', json.string)
 }
 
 // A JSON integer. A number too large for an `Int` fails here rather than
 // arriving truncated — see `scarlet/json`.
 pub fn int() Decoder(Int) {
-	scalar('an integer', fn(d) json.int(d))
+	scalar('an integer', json.int)
 }
 
 pub fn float() Decoder(Float) {
-	scalar('a number', fn(d) json.float(d))
+	scalar('a number', json.float)
 }
 
 pub fn bool() Decoder(Bool) {
-	scalar('a boolean', fn(d) json.bool(d))
+	scalar('a boolean', json.bool)
 }
 
 // A 64-bit integer that arrived as a JSON *string*.

--- a/crates/scarlet_core/src/std/scarlet/net/tls.scrl
+++ b/crates/scarlet_core/src/std/scarlet/net/tls.scrl
@@ -93,16 +93,8 @@ pub type TlsError {
 // is not a decision a runtime should take on a program's behalf. Nothing is
 // therefore resumed across separate runs of a program.
 pub fn connect(host String, port Int) Result(TlsSocket, TlsError) {
-	// An explicit match, where this module would otherwise backpass. The
-	// backpassing form —
-	// `sock <- result.then(result.map_err(net.connect(host, port), Transport))`
-	// — miscompiles: a jump-over is patched to land on the first instruction of
-	// this body instead of past it, which check_parity catches. T-129. Restore
-	// the backpassing once that is fixed.
-	match net.connect(host, port) {
-		Ok(sock) -> handshake(sock, host)
-		Err(e) -> Err(Transport(e))
-	}
+	sock <- result.then(result.map_err(net.connect(host, port), Transport))
+	handshake(sock, host)
 }
 
 // Complete a TLS handshake over an already-connected socket, verifying the


### PR DESCRIPTION
`#30` fixed the eta-wrapper jump-over. Both stdlib workarounds written around it can go, and the comments explaining them go with them — a comment describing a workaround that is not there is worse than no comment.

- `net/tls.scrl` — `connect` is back to backpassing: `sock <- result.then(result.map_err(net.connect(host, port), Transport))`
- `json/decode.scrl` — the four `fn(d) json.x(d)` lambdas are bare builtins again. `scalar`'s `read fn(json.Doc) Option(a)` parameter is unchanged.

8 additions / 22 deletions across two files. No goldens moved. Nothing in the tree mentions T-129 or T-135 any more.

## Why this is evidence and not just a green

Each removal was watched failing with **only the compiler half of `6fe491b` reverted**, which is what shows the removal is load-bearing on that fix rather than merely coincident with it.

**TLS** — `Jump at 12963 targets 12972 — inside function 302 (connect), whose body is [12972, 12990)`, 4 failures.
**JSON** — `Jump at 10775 targets 10780 — inside function 239 (string_value), whose body is [10780, 10785)`, 4 failures.

Both restored: `check_parity` 9, `golden_examples` 43, `stdlib` 14, `vm_exec` 52, `vm_tls` 9.

## Gates

`fmt` 0 · `clippy` 0 · `test --workspace` 0 (37 binaries, 1264 passed) · `gen-editor-syntax --check` 0