### PR TITLE
decode: bind-shaped decoders that still accumulate, with no placeholder

### DIFF
--- a/crates/scarlet/tests/golden/programs/decoders.stdout
+++ b/crates/scarlet/tests/golden/programs/decoders.stdout
@@ -1,0 +1,38 @@
+-- a forty-member record, one line per member --
+40 members    10 hi mentions=2 guild=present(13) nick=null ref=absent
+40, two wrong 2: .id: expected a quoted integer, found an integer
+.tts: expected a boolean, found a string
+
+-- independent members accumulate, past the old five-member ceiling --
+8 members ok  Row{ a: 1, b: x, c: True, d: 2, e: y, f: False, g: 3, h: z }
+3 of 8 wrong  3: .a: expected an integer, found a string
+.e: expected a string, found an integer
+.h: expected a string, found a boolean
+only 1st wrong1: .a: expected an integer, found a string
+
+-- absent, null and present stay three outcomes --
+absent        absent -> Some(held)
+null          null -> None
+present       present(ada) -> Some(ada)
+bad id + null 1: .id: expected an integer, found a string
+bad optional  1: .nick: expected a string, found an integer
+
+-- one_of: the same field written 2 or 2.0 --
+2 and 2.0     Pair{ v: 2, w: 2 }
+2.0 and 2     Pair{ v: 2, w: 2 }
+neither       2: .v: expected an integer, found a string
+.v: expected a number, found a string
+
+-- fail takes no value, at any type --
+fail String   1: <root>: expected a string this program approves of, found an object
+fail Message  1: <root>: expected a message this program approves of, found an object
+halts after   1: <root>: expected a string this program approves of, found an object
+
+-- guard refines without halting; then+fail halts --
+guard, both   2: .v: expected a positive integer, found an integer
+.w: expected a positive integer, found an integer
+then+fail     1: .v: expected a positive integer, found an integer
+
+-- a bad discriminant reports itself, not an untaken branch --
+chat          Chat(hi)
+bad tag       1: .t: expected a string, found an integer

--- a/crates/scarlet/tests/golden_examples.rs
+++ b/crates/scarlet/tests/golden_examples.rs
@@ -271,6 +271,13 @@ suite! {
         // adversarial answers: 1e400, a lone surrogate, invalid UTF-8, the
         // 64-bit boundary, duplicate keys and deep nesting.
         json,
+        // scarlet/json/decode's own shape: a forty-member record written one
+        // flat line per member, independent members accumulating their failures
+        // past the old five-member ceiling, three-way presence under that
+        // accumulation, one_of over 2 vs 2.0, and the two places where
+        // accumulation is deliberately given up — `fail`, and `then`'s
+        // dependent continuation.
+        decoders,
     ],
 
     // No golden, because there is no fixed output: `http_server` ends in an

--- a/crates/scarlet/tests/programs/decoders.scrl
+++ b/crates/scarlet/tests/programs/decoders.scrl
@@ -1,0 +1,417 @@
+import scarlet/array
+import scarlet/float
+import scarlet/json
+import scarlet/json/decode
+import scarlet/json/field
+
+// The decoder API at the scale it exists for.
+//
+// `json.scrl` covers the parser and the presence states. This file covers the
+// shape of `scarlet/json/decode` itself: that a record decoder is one flat
+// line per member with no arity ceiling, that independent members accumulate
+// their failures instead of masking each other, and that nothing anywhere
+// asks the caller for a value of the type being decoded.
+//
+// Values are passed to `line` rather than interpolated into the label, so no
+// string literal ever sits inside an enclosing interpolation (T-136).
+
+fn line(label String, value String) Nil {
+	println('${label}${value}')
+}
+
+// Decode and report how many failures came back, then each of them. The count
+// is the point: an API that stops at the first bad member always prints 1.
+fn failures(src String, dec decode.Decoder(a)) String {
+	match json.parse(src) {
+		Err(e) -> 'parse error: ${json.parse_error_message(e)}'
+		Ok(d) -> match decode.run(dec, d) {
+			Ok(_) -> 'decoded'
+			Err(fs) -> '${array.length(fs)}: ${decode.failures_to_string(fs)}'
+		}
+	}
+}
+
+fn decoded(src String, dec decode.Decoder(a)) String {
+	match json.parse(src) {
+		Err(e) -> 'parse error: ${json.parse_error_message(e)}'
+		Ok(d) -> match decode.run(dec, d) {
+			Err(fs) -> 'decode error: ${decode.failures_to_string(fs)}'
+			Ok(v) -> '${v}'
+		}
+	}
+}
+
+// Forty is not a round number chosen for effect: it is the width of the
+// Discord object this API was specified against. The previous shape topped out
+// at `map5`, so this record could not be written at all.
+type Message {
+	id Int
+	channel_id Int
+	guild_id field.Field(Int)
+	author_id Int
+	author_name String
+	author_bot Bool
+	content String
+	timestamp String
+	edited_timestamp field.Field(String)
+	tts Bool
+	mention_everyone Bool
+	mentions Array(Int)
+	mention_roles Array(Int)
+	attachment_ids Array(Int)
+	embed_titles Array(String)
+	reaction_counts Array(Int)
+	nonce String
+	pinned Bool
+	webhook_id field.Field(Int)
+	kind Int
+	application_id field.Field(Int)
+	reference_id field.Field(Int)
+	flags Int
+	thread_id field.Field(Int)
+	component_ids Array(Int)
+	sticker_ids Array(Int)
+	position Int
+	member_nick field.Field(String)
+	member_roles Array(Int)
+	referenced_message_id field.Field(Int)
+	resolved_user_ids Array(Int)
+	poll_question field.Field(String)
+	call_participants Array(Int)
+	interaction_id field.Field(Int)
+	interaction_name field.Field(String)
+	application_name field.Field(String)
+	role_subscription field.Field(String)
+	purchase_kind field.Field(String)
+	snapshot_ids Array(Int)
+	ping_count Int
+}
+
+fn message() decode.Decoder(Message) {
+	id <- decode.take('id', decode.int_string())
+	channel_id <- decode.take('channel_id', decode.int_string())
+	guild_id <- decode.take_optional('guild_id', decode.int_string())
+	author_id <- decode.take('author_id', decode.int_string())
+	author_name <- decode.take('author_name', decode.string_value())
+	author_bot <- decode.take('author_bot', decode.bool())
+	content <- decode.take('content', decode.string_value())
+	timestamp <- decode.take('timestamp', decode.string_value())
+	edited_timestamp <- decode.take_optional('edited_timestamp', decode.string_value())
+	tts <- decode.take('tts', decode.bool())
+	mention_everyone <- decode.take('mention_everyone', decode.bool())
+	mentions <- decode.take('mentions', decode.list(decode.int_string()))
+	mention_roles <- decode.take('mention_roles', decode.list(decode.int_string()))
+	attachment_ids <- decode.take('attachment_ids', decode.list(decode.int_string()))
+	embed_titles <- decode.take('embed_titles', decode.list(decode.string_value()))
+	reaction_counts <- decode.take('reaction_counts', decode.list(decode.int()))
+	nonce <- decode.take('nonce', decode.string_value())
+	pinned <- decode.take('pinned', decode.bool())
+	webhook_id <- decode.take_optional('webhook_id', decode.int_string())
+	kind <- decode.take('type', decode.int())
+	application_id <- decode.take_optional('application_id', decode.int_string())
+	reference_id <- decode.take_optional('reference_id', decode.int_string())
+	flags <- decode.take('flags', decode.int())
+	thread_id <- decode.take_optional('thread_id', decode.int_string())
+	component_ids <- decode.take('component_ids', decode.list(decode.int_string()))
+	sticker_ids <- decode.take('sticker_ids', decode.list(decode.int_string()))
+	position <- decode.take('position', decode.int())
+	member_nick <- decode.take_optional('member_nick', decode.string_value())
+	member_roles <- decode.take('member_roles', decode.list(decode.int_string()))
+	referenced_message_id <- decode.take_optional('referenced_message_id', decode.int_string())
+	resolved_user_ids <- decode.take('resolved_user_ids', decode.list(decode.int_string()))
+	poll_question <- decode.take_optional('poll_question', decode.string_value())
+	call_participants <- decode.take('call_participants', decode.list(decode.int_string()))
+	interaction_id <- decode.take_optional('interaction_id', decode.int_string())
+	interaction_name <- decode.take_optional('interaction_name', decode.string_value())
+	application_name <- decode.take_optional('application_name', decode.string_value())
+	role_subscription <- decode.take_optional('role_subscription', decode.string_value())
+	purchase_kind <- decode.take_optional('purchase_kind', decode.string_value())
+	snapshot_ids <- decode.take('snapshot_ids', decode.list(decode.int_string()))
+	ping_count <- decode.take('ping_count', decode.int())
+	decode.succeed(
+		Message(
+			id: id,
+			channel_id: channel_id,
+			guild_id: guild_id,
+			author_id: author_id,
+			author_name: author_name,
+			author_bot: author_bot,
+			content: content,
+			timestamp: timestamp,
+			edited_timestamp: edited_timestamp,
+			tts: tts,
+			mention_everyone: mention_everyone,
+			mentions: mentions,
+			mention_roles: mention_roles,
+			attachment_ids: attachment_ids,
+			embed_titles: embed_titles,
+			reaction_counts: reaction_counts,
+			nonce: nonce,
+			pinned: pinned,
+			webhook_id: webhook_id,
+			kind: kind,
+			application_id: application_id,
+			reference_id: reference_id,
+			flags: flags,
+			thread_id: thread_id,
+			component_ids: component_ids,
+			sticker_ids: sticker_ids,
+			position: position,
+			member_nick: member_nick,
+			member_roles: member_roles,
+			referenced_message_id: referenced_message_id,
+			resolved_user_ids: resolved_user_ids,
+			poll_question: poll_question,
+			call_participants: call_participants,
+			interaction_id: interaction_id,
+			interaction_name: interaction_name,
+			application_name: application_name,
+			role_subscription: role_subscription,
+			purchase_kind: purchase_kind,
+			snapshot_ids: snapshot_ids,
+			ping_count: ping_count,
+		),
+	)
+}
+
+// `id` and `tts` are parameters so the same payload can be handed to the
+// decoder well-formed and malformed without a second copy of it.
+fn wide(id String, tts String) String {
+	'{"id":${id},"channel_id":"11","guild_id":"13","author_id":"12","author_name":"ada","author_bot":false,"content":"hi","timestamp":"t0","tts":${tts},"mention_everyone":false,"mentions":["21","22"],"mention_roles":[],"attachment_ids":[],"embed_titles":["e"],"reaction_counts":[3],"nonce":"n","pinned":false,"type":0,"flags":64,"component_ids":[],"sticker_ids":[],"position":1,"member_nick":null,"member_roles":[],"resolved_user_ids":[],"call_participants":[],"snapshot_ids":[],"ping_count":2}'
+}
+
+fn summarise(m Message) String {
+	nick = field.fold(m.member_nick, fn() 'absent', fn() 'null', fn(v) 'present(${v})')
+	ref = field.fold(m.referenced_message_id, fn() 'absent', fn() 'null', fn(v) 'present(${v})')
+	guild = field.fold(m.guild_id, fn() 'absent', fn() 'null', fn(v) 'present(${v})')
+	'${m.id} ${m.content} mentions=${array.length(
+		m.mentions,
+	)} guild=${guild} nick=${nick} ref=${ref}'
+}
+
+fn wide_summary(src String) String {
+	match json.parse(src) {
+		Err(e) -> 'parse error: ${json.parse_error_message(e)}'
+		Ok(d) -> match decode.run(message(), d) {
+			Err(fs) -> '${array.length(fs)}: ${decode.failures_to_string(fs)}'
+			Ok(m) -> summarise(m)
+		}
+	}
+}
+
+type Row {
+	a Int
+	b String
+	c Bool
+	d Int
+	e String
+	f Bool
+	g Int
+	h String
+}
+
+fn row() decode.Decoder(Row) {
+	a <- decode.take('a', decode.int())
+	b <- decode.take('b', decode.string_value())
+	c <- decode.take('c', decode.bool())
+	d <- decode.take('d', decode.int())
+	e <- decode.take('e', decode.string_value())
+	f <- decode.take('f', decode.bool())
+	g <- decode.take('g', decode.int())
+	h <- decode.take('h', decode.string_value())
+	decode.succeed(Row(a: a, b: b, c: c, d: d, e: e, f: f, g: g, h: h))
+}
+
+type Patch {
+	id Int
+	nick field.Field(String)
+	topic field.Field(String)
+}
+
+fn patch() decode.Decoder(Patch) {
+	id <- decode.take('id', decode.int())
+	nick <- decode.take_optional('nick', decode.string_value())
+	topic <- decode.take_optional('topic', decode.string_value())
+	decode.succeed(Patch(id: id, nick: nick, topic: topic))
+}
+
+fn state(f field.Field(String)) String {
+	field.fold(f, fn() 'absent', fn() 'null', fn(v) 'present(${v})')
+}
+
+fn applied(src String) String {
+	match json.parse(src) {
+		Err(e) -> 'parse error: ${json.parse_error_message(e)}'
+		Ok(d) -> match decode.run(patch(), d) {
+			Err(fs) -> '${array.length(fs)}: ${decode.failures_to_string(fs)}'
+			Ok(p) -> '${state(p.nick)} -> ${field.update(p.nick, Some('held'))}'
+		}
+	}
+}
+
+fn loose_int() decode.Decoder(Int) {
+	decode.one_of(decode.int(), [decode.map(decode.float(), fn(f) float.round(f))])
+}
+
+type Pair {
+	v Int
+	w Int
+}
+
+fn pair() decode.Decoder(Pair) {
+	v <- decode.take('v', loose_int())
+	w <- decode.take('w', loose_int())
+	decode.succeed(Pair(v: v, w: w))
+}
+
+// Neither of these is handed a `String` or a `Message` to stand in for the
+// answer. `Err` inhabits `Result(a, Array(Failure))` for every `a`, and the
+// recovery channel has a `Halt` that inhabits `Recovery(a)` for every `a`.
+fn refuse_string() decode.Decoder(String) {
+	decode.fail('a string this program approves of')
+}
+
+fn refuse_message() decode.Decoder(Message) {
+	decode.fail('a message this program approves of')
+}
+
+// The price, stated: a decoder with no recovery stops accumulation there.
+// `b` and `c` below are also wrong and are not reported.
+type Three {
+	a String
+	b Int
+	c Int
+}
+
+fn halting() decode.Decoder(Three) {
+	a <- decode.also(refuse_string())
+	b <- decode.take('b', decode.int())
+	c <- decode.take('c', decode.int())
+	decode.succeed(Three(a: a, b: b, c: c))
+}
+
+fn guarded() decode.Decoder(Pair) {
+	v <- decode.take('v', decode.guard(decode.int(), fn(n) n > 0, 'a positive integer'))
+	w <- decode.take('w', decode.guard(decode.int(), fn(n) n > 0, 'a positive integer'))
+	decode.succeed(Pair(v: v, w: w))
+}
+
+fn positive_or_fail() decode.Decoder(Int) {
+	decode.then(decode.int(), fn(n) if n > 0 {
+		decode.succeed(n)
+	} else {
+		decode.fail('a positive integer')
+	})
+}
+
+fn thenned() decode.Decoder(Pair) {
+	v <- decode.take('v', positive_or_fail())
+	w <- decode.take('w', positive_or_fail())
+	decode.succeed(Pair(v: v, w: w))
+}
+
+type Event {
+	Chat(text String)
+	Beat(seq Int)
+}
+
+fn pick(t String) Result(decode.Decoder(Event), Nil) {
+	match t {
+		'CHAT' -> Ok(decode.map(decode.field('text', decode.string_value()), fn(c) Chat(c)))
+		'BEAT' -> Ok(decode.map(decode.field('seq', decode.int()), fn(s) Beat(s)))
+		_ -> Err(Nil)
+	}
+}
+
+fn event() decode.Decoder(Event) {
+	decode.tagged('t', pick)
+}
+
+pub fn main() {
+	// ------------------------------------------------------- forty members flat --
+
+	println('-- a forty-member record, one line per member --')
+
+	line('40 members    ', wide_summary(wide('"10"', 'true')))
+
+	// Two of the forty are wrong. Both are reported, and the thirty-eight between
+	// and after them were still checked.
+	line('40, two wrong ', wide_summary(wide('10', '"yes"')))
+
+	// ------------------------------------------------------- accumulation --------
+
+	println('')
+	println('-- independent members accumulate, past the old five-member ceiling --')
+
+	all_good = '{"a":1,"b":"x","c":true,"d":2,"e":"y","f":false,"g":3,"h":"z"}'
+	three_bad = '{"a":"1","b":"x","c":true,"d":2,"e":9,"f":false,"g":3,"h":true}'
+	first_bad = '{"a":"1","b":"x","c":true,"d":2,"e":"y","f":false,"g":3,"h":"z"}'
+
+	line('8 members ok  ', decoded(all_good, row()))
+	line('3 of 8 wrong  ', failures(three_bad, row()))
+
+	// The first member is the one that failed and the seven after it are fine.
+	// The result is still `Err`: a recovery value keeps the checking going, it
+	// never becomes part of an answer.
+	line('only 1st wrong', failures(first_bad, row()))
+
+	// ------------------------------------------------------- three-way presence --
+
+	println('')
+	println('-- absent, null and present stay three outcomes --')
+
+	line('absent        ', applied('{"id":1}'))
+	line('null          ', applied('{"id":1,"nick":null}'))
+	line('present       ', applied('{"id":1,"nick":"ada"}'))
+
+	// An optional member never invents a failure, and never stops accumulation:
+	// `Field(a)` is inhabited without an `a`, so its recovery is `absent` whatever
+	// the decoder inside it is. Here `id` is wrong and `nick` is null — exactly
+	// one failure, and it is `id`'s.
+	line('bad id + null ', applied('{"id":"1","nick":null}'))
+
+	// A present member of the wrong type is a failure, which is what keeps
+	// "absent" from swallowing bad input.
+	line('bad optional  ', applied('{"id":1,"nick":7}'))
+
+	// ------------------------------------------------------------------- one_of --
+
+	println('')
+	println('-- one_of: the same field written 2 or 2.0 --')
+
+	line('2 and 2.0     ', decoded('{"v":2,"w":2.0}', pair()))
+	line('2.0 and 2     ', decoded('{"v":2.0,"w":2}', pair()))
+
+	// Every alternative says what it wanted when none of them matched.
+	line('neither       ', failures('{"v":"2","w":2}', pair()))
+
+	// ------------------------------------------------- fail needs no placeholder --
+
+	println('')
+	println('-- fail takes no value, at any type --')
+
+	line('fail String   ', failures('{}', refuse_string()))
+	line('fail Message  ', failures('{}', refuse_message()))
+
+	line('halts after   ', failures('{"b":"x","c":"y"}', halting()))
+
+	// ------------------------------------------------------------------- guard --
+
+	println('')
+	println('-- guard refines without halting; then+fail halts --')
+
+	line('guard, both   ', failures('{"v":-1,"w":-2}', guarded()))
+	line('then+fail     ', failures('{"v":-1,"w":-2}', thenned()))
+
+	// ------------------------------------------------------- then short-circuits --
+
+	println('')
+	println('-- a bad discriminant reports itself, not an untaken branch --')
+
+	line('chat          ', decoded('{"t":"CHAT","text":"hi"}', event()))
+
+	// `.t` is an integer, so no branch was selected. One failure, and it names the
+	// discriminant — not `.text` or `.seq`, which belong to branches this payload
+	// never chose.
+	line('bad tag       ', failures('{"t":7,"text":9}', event()))
+}

--- a/crates/scarlet/tests/programs/json.scrl
+++ b/crates/scarlet/tests/programs/json.scrl
@@ -125,6 +125,15 @@ type User {
 	nickname field.Field(String)
 }
 
+// One line per member, and the same shape at four members as at forty.
+fn user_decoder() decode.Decoder(User) {
+	id <- decode.take('id', decode.int_string())
+	name <- decode.take('username', decode.string_value())
+	bot <- decode.also(decode.with_default('bot', decode.bool(), False))
+	nick <- decode.take_optional('nickname', decode.string_value())
+	decode.succeed(User(id, name, bot, nick))
+}
+
 type Event {
 	Message(content String)
 	Heartbeat(seq Int)
@@ -250,23 +259,15 @@ pub fn main() {
 	println('')
 	println('-- typed records --')
 
-	user_decoder = decode.map4(
-		decode.field('id', decode.int_string()),
-		decode.field('username', decode.string_value()),
-		decode.with_default('bot', decode.bool(), False),
-		decode.optional_field('nickname', decode.string_value()),
-		fn(id, name, bot, nick) User(id, name, bot, nick),
-	)
-
 	// A Discord snowflake arrives quoted precisely because a JSON number cannot
 	// carry 64 bits through a double.
 	null_nick = '{"id":"1070000000000000001","username":"ada","nickname":null}'
 	absent_nick = '{"id":"1070000000000000001","username":"ada"}'
 	set_nick = '{"id":"1070000000000000001","username":"ada","nickname":"c","bot":true}'
 
-	line('null nick     ', shown(null_nick, user_decoder))
-	line('absent nick   ', shown(absent_nick, user_decoder))
-	line('set nick      ', shown(set_nick, user_decoder))
+	line('null nick     ', shown(null_nick, user_decoder()))
+	line('absent nick   ', shown(absent_nick, user_decoder()))
+	line('set nick      ', shown(set_nick, user_decoder()))
 
 	// ------------------------------------------------- failures name their path --
 
@@ -400,7 +401,7 @@ pub fn main() {
 
 	guild_ids = decode.at(['d', 'guilds'], decode.list(decode.field('id', decode.int_string())))
 
-	line('ready user    ', shown(ready, decode.at(['d', 'user'], user_decoder)))
+	line('ready user    ', shown(ready, decode.at(['d', 'user'], user_decoder())))
 	line('ready v       ', shown(ready, decode.at(['d', 'v'], decode.int())))
 	line('ready guilds  ', shown(ready, guild_ids))
 	line('ready session ', shown(ready, decode.at(['d', 'session_id'], decode.string_value())))

--- a/crates/scarlet_core/src/std/scarlet/json/decode.scrl
+++ b/crates/scarlet_core/src/std/scarlet/json/decode.scrl
@@ -7,13 +7,53 @@ import scarlet/json/field as presence
 
 // Turning a parsed document into your own types.
 //
-// A `Decoder(a)` reads a `Doc` and produces an `a` or a list of failures.
-// Failures accumulate rather than stopping at the first one, and each carries
-// the path it happened at, so a bad field in a two-hundred-field payload names
-// itself instead of reporting "decode failed".
+// A `Decoder(a)` reads a `Doc` and produces an `a` or a list of failures. Each
+// failure carries the path it happened at, so a bad member in a two-hundred
+// member payload names itself instead of reporting "decode failed".
 //
 // Decoders read straight off the `Doc`. Nothing materialises a tree on the
-// way, so a decoder that reads six fields costs six fields.
+// way, so a decoder that reads six members costs six members.
+//
+// ## Writing one
+//
+// `take` is bind-shaped, so a record is one line per member and there is no
+// arity ceiling:
+//
+//     fn user() Decoder(User) {
+//         id <- decode.take('id', decode.int_string())
+//         name <- decode.take('username', decode.string_value())
+//         nick <- decode.take_optional('nickname', decode.string_value())
+//         decode.succeed(User(id: id, name: name, nickname: nick))
+//     }
+//
+// All three members are checked even when the first one is wrong, so a
+// malformed payload reports every bad member at once rather than one per
+// attempt. `also` does the same for a decoder that is not a member lookup.
+//
+// ## No placeholder, ever
+//
+// Nothing here asks the caller for a value of the type being decoded. Two
+// separate reasons, and both are worth knowing because losing either one
+// brings the placeholder back:
+//
+//   - `fail(expected)` produces `Decoder(a)` for any `a` without an `a`,
+//     because the value channel is `Result(a, Array(Failure))` and `Err`
+//     inhabits that for every `a`. A decoder whose value channel is an
+//     unconditional `a` cannot do this, and that is the whole cause of the
+//     placeholder in decoder libraries that have one.
+//   - Deciding to keep going after a failure does need a value of the failed
+//     decoder's type — see `Recovery`. It comes from the decoder, not from
+//     the caller: primitives carry their own, every combinator derives one
+//     from its parts, and `fail` answers `Halt`.
+//
+// ## Accumulating and stopping
+//
+// `map2` accumulates unconditionally: both decoders are named up front, so
+// neither has to be built from the other's value. `take`/`also` accumulate
+// through a `Recovery`, and stop at a decoder that has none. `then` never
+// accumulates, and that is correct rather than a limitation — its
+// continuation genuinely depends on the value, so failures found past a bad
+// discriminant would belong to a branch the payload never selected.
 //
 // ## Optional members
 //
@@ -28,12 +68,13 @@ pub type Segment {
 	At(index Int)
 }
 
-// What the document held where a failure happened.
+// What the document actually held where a failure happened.
 //
-// A closed set rather than a free string, so "the member was absent" is a
-// value a consumer can branch on rather than a sentence `field` happened to
-// write, and so every failure renders in one place instead of at each site
-// that builds one.
+// Three constructors rather than a free string, because "no such member" is a
+// state and not a description: written as text it is indistinguishable from a
+// value that happens to read that way, and nothing stops the two spellings
+// drifting apart. `FoundKind` can only be built from a kind the document
+// reported, so it cannot disagree with the document either.
 pub type Found {
 	FoundKind(kind json.Kind)
 	FoundAbsent
@@ -43,26 +84,54 @@ pub type Found {
 
 // One thing that was wrong, and where.
 //
-// `expected` stays a `String`: it describes the decoder, not the document, and
-// a caller's own decoder wants "a positive integer" — so giving it a closed
-// type would only add an escape hatch every caller-written decoder takes.
+// `expected` stays a `String` on purpose. `found` is a property of the
+// document and so is closed; `expected` is a property of the decoder and is
+// open — a caller's own decoder wants "a positive integer" — so a closed type
+// would only add an escape hatch that every caller-written decoder takes.
 pub type Failure {
 	path Array(Segment)
 	expected String
 	found Found
 }
 
+// What a decoder can still offer once it has already failed, so that the
+// members after it are checked instead of being masked by the first error.
+//
+// This is the whole of the placeholder question, and the caller is not in it:
+// primitives carry their own value, every combinator derives one from its
+// parts, and `fail` — which has no `a` to offer and must not be made to
+// invent one — answers `Halt`. A recovered value never reaches the caller:
+// any run that consults one returns `Err`.
+type Recovery(a) {
+	Resume(value a)
+	Halt
+}
+
 // Reads a `Doc`, or says what was wrong with it. Opaque so the path-threading
-// argument stays an implementation detail: build decoders with the
+// and the recovery value stay implementation details: build decoders with the
 // combinators here and run them with `run`.
+//
+// `resume` is a thunk because it is only forced on a failure path. Forcing it
+// eagerly would build the whole of the rest of a `take` chain once per member
+// on the success path.
 pub opaque type Decoder(a) {
 	step fn(Array(Segment), json.Doc) Result(a, Array(Failure))
+	resume fn() Recovery(a)
 }
 
 // Decode a document.
 pub fn run(dec Decoder(a), doc json.Doc) Result(a, Array(Failure)) {
-	Decoder(step) = dec
-	step([], doc)
+	run_at(dec, [], doc)
+}
+
+fn run_at(dec Decoder(a), path Array(Segment), doc json.Doc) Result(a, Array(Failure)) {
+	Decoder(step, _) = dec
+	step(path, doc)
+}
+
+fn recovery(dec Decoder(a)) Recovery(a) {
+	Decoder(_, resume) = dec
+	resume()
 }
 
 // Render a path as `.field.list[3].name`, or `<root>` for the top level.
@@ -112,7 +181,7 @@ pub fn found_to_string(f Found) String {
 	}
 }
 
-// The name of what a `Doc` actually holds, for the `found` half of a failure.
+// The name of what a `Doc` holds, for the `found` half of a failure.
 fn kind_to_string(k json.Kind) String {
 	match k {
 		json.NullKind -> 'null'
@@ -131,37 +200,47 @@ fn one_failure(path Array(Segment), expected String, d json.Doc) Array(Failure) 
 
 // A decoder that ignores the document and succeeds.
 pub fn succeed(value a) Decoder(a) {
-	Decoder(fn(_path, _doc) Ok(value))
+	Decoder(step: fn(_path, _doc) Ok(value), resume: fn() Resume(value))
 }
 
 // A decoder that always fails, naming what it wanted.
+//
+// No placeholder: `Err` inhabits `Result(a, Array(Failure))` without an `a`,
+// and `Halt` inhabits `Recovery(a)` without one either.
 pub fn fail(expected String) Decoder(a) {
-	Decoder(fn(path, doc) Err(one_failure(path, expected, doc)))
+	Decoder(step: fn(path, doc) Err(one_failure(path, expected, doc)), resume: fn() Halt)
 }
 
-fn scalar(expected String, read fn(json.Doc) Option(a)) Decoder(a) {
-	Decoder(fn(path, doc) match read(doc) {
-		Some(v) -> Ok(v)
-		None -> Err(one_failure(path, expected, doc))
-	})
+// `resume_with` is the one place in the module where a value of the decoded
+// type is written down rather than derived, and it is written by the library
+// for a closed set of JSON scalars. It is unreachable from outside: a caller
+// cannot build a `Decoder` except through the combinators here.
+fn scalar(expected String, resume_with a, read fn(json.Doc) Option(a)) Decoder(a) {
+	Decoder(
+		step: fn(path, doc) match read(doc) {
+			Some(v) -> Ok(v)
+			None -> Err(one_failure(path, expected, doc))
+		},
+		resume: fn() Resume(resume_with),
+	)
 }
 
 pub fn string_value() Decoder(String) {
-	scalar('a string', json.string)
+	scalar('a string', '', json.string)
 }
 
 // A JSON integer. A number too large for an `Int` fails here rather than
 // arriving truncated — see `scarlet/json`.
 pub fn int() Decoder(Int) {
-	scalar('an integer', json.int)
+	scalar('an integer', 0, json.int)
 }
 
 pub fn float() Decoder(Float) {
-	scalar('a number', json.float)
+	scalar('a number', 0.0, json.float)
 }
 
 pub fn bool() Decoder(Bool) {
-	scalar('a boolean', json.bool)
+	scalar('a boolean', False, json.bool)
 }
 
 // A 64-bit integer that arrived as a JSON *string*.
@@ -175,13 +254,16 @@ pub fn bool() Decoder(Bool) {
 // its positive half. `+` is not: JSON has no leading plus on a number and a
 // quoted integer is the same integer in quotes.
 pub fn int_string() Decoder(Int) {
-	Decoder(fn(path, doc) match json.string(doc) {
-		None -> Err(one_failure(path, 'a quoted integer', doc))
-		Some(s) -> match parse_signed(s) {
-			Ok(n) -> Ok(n)
-			Err(Nil) -> Err([Failure(path, 'a quoted integer', FoundText('the string "${s}"'))])
-		}
-	})
+	Decoder(
+		step: fn(path, doc) match json.string(doc) {
+			None -> Err(one_failure(path, 'a quoted integer', doc))
+			Some(s) -> match parse_signed(s) {
+				Ok(n) -> Ok(n)
+				Err(Nil) -> Err([Failure(path, 'a quoted integer', FoundText('the string "${s}"'))])
+			}
+		},
+		resume: fn() Resume(0),
+	)
 }
 
 // `binary.parse_int` reads unsigned digits and treats `-` as a non-digit, so
@@ -207,96 +289,157 @@ fn parse_signed(s String) Result(Int, Nil) {
 
 // `null`, decoded as a value of your choosing.
 pub fn null_as(value a) Decoder(a) {
-	Decoder(fn(path, doc) if json.is_null(doc) {
-		Ok(value)
-	} else {
-		Err(one_failure(path, 'null', doc))
-	})
+	Decoder(
+		step: fn(path, doc) if json.is_null(doc) {
+			Ok(value)
+		} else {
+			Err(one_failure(path, 'null', doc))
+		},
+		resume: fn() Resume(value),
+	)
 }
 
 // Transform a decoder's result.
 pub fn map(dec Decoder(a), f fn(a) b) Decoder(b) {
-	Decoder(step) = dec
-	Decoder(fn(path, doc) match step(path, doc) {
-		Ok(v) -> Ok(f(v))
-		Err(e) -> Err(e)
-	})
+	Decoder(step, resume) = dec
+	Decoder(
+		step: fn(path, doc) match step(path, doc) {
+			Ok(v) -> Ok(f(v))
+			Err(e) -> Err(e)
+		},
+		resume: fn() match resume() {
+			Resume(v) -> Resume(f(v))
+			Halt -> Halt
+		},
+	)
 }
 
-// Choose the next decoder from what the last one produced. Sequential, so a
-// failure here stops rather than accumulating — use `map2` and friends for
-// independent fields, which is where accumulation matters.
+// Choose the next decoder from what the last one produced.
+//
+// Sequential and short-circuiting, and deliberately so: the continuation
+// depends on the value, so anything found after a failure here would have
+// been read by whichever branch a substitute value happened to select. Use
+// `take`/`also` for members that do not depend on each other, which is where
+// accumulation belongs.
 pub fn then(dec Decoder(a), f fn(a) Decoder(b)) Decoder(b) {
-	Decoder(step) = dec
-	Decoder(fn(path, doc) match step(path, doc) {
-		Err(e) -> Err(e)
-		Ok(v) -> {
-			Decoder(next) = f(v)
-			next(path, doc)
-		}
-	})
+	Decoder(step, resume) = dec
+	Decoder(
+		step: fn(path, doc) match step(path, doc) {
+			Err(e) -> Err(e)
+			Ok(v) -> run_at(f(v), path, doc)
+		},
+		resume: fn() match resume() {
+			Resume(v) -> recovery(f(v))
+			Halt -> Halt
+		},
+	)
 }
 
-// Combine two decoders, keeping BOTH sets of failures. This is what makes a
-// malformed payload report every bad field at once instead of one per attempt.
+// Run `dec`, hand its value to the rest of the decoder, and keep checking the
+// rest even when `dec` failed.
+//
+// This is the combinator the module is shaped around, because backpassing
+// makes it one flat line per member with no arity ceiling:
+//
+//     id <- decode.also(decode.field('id', decode.int_string()))
+//
+// When `dec` fails, its `Recovery` supplies a stand-in so that the rest can be
+// built and run, and its failures are appended to `dec`'s. The stand-in never
+// escapes: this returns `Err` whenever `dec` failed, whatever the rest did
+// with it. A `dec` that answers `Halt` — one built from `fail` — stops here,
+// which is the one case where accumulation is given up rather than chosen.
+pub fn also(dec Decoder(a), k fn(a) Decoder(b)) Decoder(b) {
+	Decoder(step, resume) = dec
+	Decoder(
+		step: fn(path, doc) match step(path, doc) {
+			Ok(v) -> run_at(k(v), path, doc)
+			Err(e) -> match resume() {
+				Halt -> Err(e)
+				Resume(v) -> match run_at(k(v), path, doc) {
+					Ok(_) -> Err(e)
+					Err(rest) -> Err([..e, ..rest])
+				}
+			}
+		},
+		resume: fn() match resume() {
+			Resume(v) -> recovery(k(v))
+			Halt -> Halt
+		},
+	)
+}
+
+// A required member, handed to the rest of the decoder. `also` over `field`.
+pub fn take(name String, inner Decoder(a), k fn(a) Decoder(b)) Decoder(b) {
+	also(field(name, inner), k)
+}
+
+// A member that may be absent, may be null, or may hold a value, handed to
+// the rest of the decoder as a `Field(a)`. `also` over `optional_field`.
+pub fn take_optional(
+	name String,
+	inner Decoder(a),
+	k fn(presence.Field(a)) Decoder(b),
+) Decoder(b) {
+	also(optional_field(name, inner), k)
+}
+
+// Combine two decoders, keeping BOTH sets of failures.
+//
+// Unlike `also` this needs no recovery value at all: both decoders are named
+// up front, so neither has to be built from the other's value.
 pub fn map2(d1 Decoder(a), d2 Decoder(b), f fn(a, b) c) Decoder(c) {
-	Decoder(s1) = d1
-	Decoder(s2) = d2
-	Decoder(fn(path, doc) match (s1(path, doc), s2(path, doc)) {
-		(Ok(a), Ok(b)) -> Ok(f(a, b))
-		(Err(e1), Err(e2)) -> Err([..e1, ..e2])
-		(Err(e1), Ok(_)) -> Err(e1)
-		(Ok(_), Err(e2)) -> Err(e2)
-	})
+	Decoder(s1, r1) = d1
+	Decoder(s2, r2) = d2
+	Decoder(
+		step: fn(path, doc) match (s1(path, doc), s2(path, doc)) {
+			(Ok(a), Ok(b)) -> Ok(f(a, b))
+			(Err(e1), Err(e2)) -> Err([..e1, ..e2])
+			(Err(e1), Ok(_)) -> Err(e1)
+			(Ok(_), Err(e2)) -> Err(e2)
+		},
+		resume: fn() match (r1(), r2()) {
+			(Resume(a), Resume(b)) -> Resume(f(a, b))
+			_ -> Halt
+		},
+	)
 }
 
-pub fn map3(d1 Decoder(a), d2 Decoder(b), d3 Decoder(c), f fn(a, b, c) d) Decoder(d) {
-	map2(map2(d1, d2, fn(x, y) (x, y)), d3, fn(xy, z) {
-		(x, y) = xy
-		f(x, y, z)
-	})
-}
-
-pub fn map4(
-	d1 Decoder(a),
-	d2 Decoder(b),
-	d3 Decoder(c),
-	d4 Decoder(d),
-	f fn(a, b, c, d) e,
-) Decoder(e) {
-	map2(map3(d1, d2, d3, fn(x, y, z) (x, y, z)), d4, fn(xyz, w) {
-		(x, y, z) = xyz
-		f(x, y, z, w)
-	})
-}
-
-pub fn map5(
-	d1 Decoder(a),
-	d2 Decoder(b),
-	d3 Decoder(c),
-	d4 Decoder(d),
-	d5 Decoder(e),
-	f fn(a, b, c, d, e) g,
-) Decoder(g) {
-	map2(map4(d1, d2, d3, d4, fn(x, y, z, w) (x, y, z, w)), d5, fn(xyzw, v) {
-		(x, y, z, w) = xyzw
-		f(x, y, z, w, v)
-	})
+// Narrow a decoder to the values that satisfy `ok`.
+//
+// The refinement that keeps its type, and so keeps its recovery: prefer it to
+// `then(dec, fn(v) if ok(v) { succeed(v) } else { fail(expected) })`, which
+// halts accumulation at the first member that uses it.
+pub fn guard(dec Decoder(a), ok fn(a) Bool, expected String) Decoder(a) {
+	Decoder(step, resume) = dec
+	Decoder(
+		step: fn(path, doc) match step(path, doc) {
+			Err(e) -> Err(e)
+			Ok(v) -> if ok(v) {
+				Ok(v)
+			} else {
+				Err(one_failure(path, expected, doc))
+			}
+		},
+		resume: resume,
+	)
 }
 
 // A required member, decoded with `inner`. A member that is missing is a
 // failure; a member that is `null` is passed to `inner`, which will fail
 // unless it is a decoder that accepts null.
 pub fn field(name String, inner Decoder(a)) Decoder(a) {
-	Decoder(step) = inner
-	Decoder(fn(path, doc) {
-		here = [..path, Key(name)]
-		match member(here, doc, name) {
-			Err(e) -> Err(e)
-			Ok(Some(child)) -> step(here, child)
-			Ok(None) -> Err([Failure(here, 'a member named "${name}"', FoundAbsent)])
-		}
-	})
+	Decoder(step, resume) = inner
+	Decoder(
+		step: fn(path, doc) {
+			here = [..path, Key(name)]
+			match member(here, doc, name) {
+				Err(e) -> Err(e)
+				Ok(Some(child)) -> step(here, child)
+				Ok(None) -> Err([Failure(here, 'a member named "${name}"', FoundAbsent)])
+			}
+		},
+		resume: resume,
+	)
 }
 
 // The member `name` of `doc`, or the failure that `doc` is not an object at
@@ -334,32 +477,43 @@ fn member(
 // Optional is about the member, not about the document. A `doc` that is not
 // an object is a failure here exactly as it is in `field` — otherwise a
 // decoder with no required fields accepts anything at all.
+//
+// Its recovery is `absent` whatever `inner` is, because `Field(a)` is
+// inhabited without an `a`. So an optional member never stops accumulation,
+// even when the decoder inside it would.
 pub fn optional_field(name String, inner Decoder(a)) Decoder(presence.Field(a)) {
-	Decoder(step) = inner
-	Decoder(fn(path, doc) {
-		here = [..path, Key(name)]
-		match member(here, doc, name) {
-			Err(e) -> Err(e)
-			Ok(None) -> Ok(presence.absent())
-			Ok(Some(child)) -> if json.is_null(child) {
-				Ok(presence.null())
-			} else {
-				match step(here, child) {
-					Ok(v) -> Ok(presence.present(v))
-					Err(e) -> Err(e)
+	Decoder(step, _) = inner
+	Decoder(
+		step: fn(path, doc) {
+			here = [..path, Key(name)]
+			match member(here, doc, name) {
+				Err(e) -> Err(e)
+				Ok(None) -> Ok(presence.absent())
+				Ok(Some(child)) -> if json.is_null(child) {
+					Ok(presence.null())
+				} else {
+					match step(here, child) {
+						Ok(v) -> Ok(presence.present(v))
+						Err(e) -> Err(e)
+					}
 				}
 			}
-		}
-	})
+		},
+		resume: fn() Resume(presence.absent()),
+	)
 }
 
 // Every element of an array, each decoded with `inner`. Element failures
 // accumulate and carry their index.
 pub fn list(inner Decoder(a)) Decoder(Array(a)) {
-	Decoder(fn(path, doc) match json.kind(doc) {
-		json.ArrayKind -> collect_list(inner, path, json.elements(doc), 0, [], [])
-		_ -> Err(one_failure(path, 'an array', doc))
-	})
+	Decoder(
+		step: fn(path, doc) match json.kind(doc) {
+			json.ArrayKind -> collect_list(inner, path, json.elements(doc), 0, [], [])
+			_ -> Err(one_failure(path, 'an array', doc))
+		},
+		// An array of nothing needs nothing of `inner`.
+		resume: fn() Resume([]),
+	)
 }
 
 fn collect_list(
@@ -375,12 +529,9 @@ fn collect_list(
 			[] -> Ok(oks)
 			_ -> Err(errs)
 		}
-		[head, ..tail] -> {
-			Decoder(step) = inner
-			match step([..path, At(i)], head) {
-				Ok(v) -> collect_list(inner, path, tail, i + 1, [..oks, v], errs)
-				Err(e) -> collect_list(inner, path, tail, i + 1, oks, [..errs, ..e])
-			}
+		[head, ..tail] -> match run_at(inner, [..path, At(i)], head) {
+			Ok(v) -> collect_list(inner, path, tail, i + 1, [..oks, v], errs)
+			Err(e) -> collect_list(inner, path, tail, i + 1, oks, [..errs, ..e])
 		}
 	}
 }
@@ -389,10 +540,13 @@ fn collect_list(
 // list rather than a `Map`, because JSON preserves member order and duplicate
 // keys and a map does not.
 pub fn dict(inner Decoder(a)) Decoder(Array((String, a))) {
-	Decoder(fn(path, doc) match json.kind(doc) {
-		json.ObjectKind -> collect_dict(inner, path, json.entries(doc), [], [])
-		_ -> Err(one_failure(path, 'an object', doc))
-	})
+	Decoder(
+		step: fn(path, doc) match json.kind(doc) {
+			json.ObjectKind -> collect_dict(inner, path, json.entries(doc), [], [])
+			_ -> Err(one_failure(path, 'an object', doc))
+		},
+		resume: fn() Resume([]),
+	)
 }
 
 fn collect_dict(
@@ -407,12 +561,9 @@ fn collect_dict(
 			[] -> Ok(oks)
 			_ -> Err(errs)
 		}
-		[(k, v), ..tail] -> {
-			Decoder(step) = inner
-			match step([..path, Key(k)], v) {
-				Ok(decoded) -> collect_dict(inner, path, tail, [..oks, (k, decoded)], errs)
-				Err(e) -> collect_dict(inner, path, tail, oks, [..errs, ..e])
-			}
+		[(k, v), ..tail] -> match run_at(inner, [..path, Key(k)], v) {
+			Ok(decoded) -> collect_dict(inner, path, tail, [..oks, (k, decoded)], errs)
+			Err(e) -> collect_dict(inner, path, tail, oks, [..errs, ..e])
 		}
 	}
 }
@@ -420,16 +571,18 @@ fn collect_dict(
 // The first decoder that succeeds. If all of them fail, every failure is
 // reported — a union that matched nothing should say what each arm wanted.
 //
-// The first alternative is a parameter of its own so that "no alternatives" is
-// not something this can be run with. `one_of([])` used to type-check and then
-// fail at decode time with a failure describing the decoder rather than the
-// document, which is not a `Found` at all.
+// The first alternative is a parameter of its own so that "no alternatives"
+// is not something this can be run with. `one_of([])` used to type-check and
+// then fail at decode time with a failure describing the decoder rather than
+// the document.
 pub fn one_of(first Decoder(a), rest Array(Decoder(a))) Decoder(a) {
-	Decoder(step) = first
-	Decoder(fn(path, doc) match step(path, doc) {
-		Ok(v) -> Ok(v)
-		Err(e) -> try_each(rest, path, doc, e)
-	})
+	Decoder(
+		step: fn(path, doc) match run_at(first, path, doc) {
+			Ok(v) -> Ok(v)
+			Err(e) -> try_each(rest, path, doc, e)
+		},
+		resume: fn() recovery(first),
+	)
 }
 
 fn try_each(
@@ -440,12 +593,9 @@ fn try_each(
 ) Result(a, Array(Failure)) {
 	match decoders {
 		[] -> Err(errs)
-		[head, ..tail] -> {
-			Decoder(step) = head
-			match step(path, doc) {
-				Ok(v) -> Ok(v)
-				Err(e) -> try_each(tail, path, doc, [..errs, ..e])
-			}
+		[head, ..tail] -> match run_at(head, path, doc) {
+			Ok(v) -> Ok(v)
+			Err(e) -> try_each(tail, path, doc, [..errs, ..e])
 		}
 	}
 }
@@ -468,7 +618,10 @@ pub fn tagged_int(tag String, pick fn(Int) Result(Decoder(a), Nil)) Decoder(a) {
 }
 
 fn unknown_tag(tag String, found String) Decoder(a) {
-	Decoder(fn(path, _doc) Err([Failure([..path, Key(tag)], 'a known tag', FoundText(found))]))
+	Decoder(
+		step: fn(path, _doc) Err([Failure([..path, Key(tag)], 'a known tag', FoundText(found))]),
+		resume: fn() Halt,
+	)
 }
 
 // Decode at a path of member names, for reaching one value out of a nested


### PR DESCRIPTION
The `map2`…`map5` ladder stops at 5 and `map3` is literally `map2(map2(…))`, so a 40-field object could not be written at all. This replaces it with backpassing, keeps multi-error accumulation, and **never asks the caller for a placeholder value**.

## The design question, and where the wall actually is

The trilemma is {bind ergonomics, accumulation past a failure, no witness of the decoded type} — a library gets two. Backpassing desugars `x <- f(d)` to `f(d, fn(x) rest)`; the continuation is opaque, so by parametricity the only way to reach the `b` in `fn(a) Decoder(b)` is to apply it to an `a`. When the step failed there is no `a`, and Scarlet is strict with no bottom. Witness, or short-circuit.

**But the objection to Gleam is not the witness — it is being asked for one, and that distinction is the whole design.**

Gleam's `Decoder(a)` is `fn(Dynamic) #(a, List(DecodeError))`: an **unconditional** value channel, so every decoder must always produce an `a`, and `decode.failure(zero, expected)` is the bill. Scarlet's is `Result(a, Array(Failure))`, and `Err` inhabits that for every `a` — which is exactly why `fail` needs nothing here. **The zero is the price of an unconditional value channel, not the price of bind.**

So keep the conditional channel and move the recovery witness onto the *decoder*, where the library writes it once:

```scarlet
type Recovery(a) { Resume(value a) | Halt }   // private — no public API mentions it
```

Primitives carry their own; every combinator derives one from its parts; `optional_field` answers `absent` always, because `Field(a)` is inhabited without an `a`. `also` runs the continuation against the witness to collect its failures, then **still returns `Err`** — a recovered value can never reach an answer.

## Before / after

5 members went from a `map5` call with a 5-argument lambda to five `<-` lines. **40 members could not be written before**; after, it is 40 lines with no nesting — real and running in `tests/programs/decoders.scrl`, and with 2 of the 40 malformed the golden reports both, with the 38 between them still checked.

## Given up, stated rather than hidden

1. A decoder built from `fail` answers `Halt` and stops accumulating there. `guard(dec, ok, expected)` keeps its type and so keeps its recovery — `guard` reports 2 where `then+fail` reports 1.
2. `then` never accumulates. That is correct rather than conceded: failures past a bad discriminant belong to a branch the payload never selected.

## Type-system improvements, each proved by a compiler error on the old spelling

- `one_of(first, rest)` is non-empty by construction — `one_of([])` was a *runtime* failure describing the decoder rather than the document.
- `Failure.found` is a `Found`, not a `String` — `'no such member'` was a magic string indistinguishable from a value that reads that way.
- `fail` takes no value at any type: `decode.fail('a user', User(name: ''))` → `Expected 1 argument(s), got 2`.

## Gates

`fmt` 0 · `clippy` 0 · `test --workspace` 0 (42 binaries, 1265 passed) · `gen-editor-syntax --check` 0

**No goldens moved** — `json.stdout` is not in the diff, so no type id shifted.

Follow-ups filed: **T-212** (`wire.scrl`'s five helpers and 40 call sites), **T-211** (`ApplicativeDo` in `desugar.rs` — the compiler can see whether a backpass continuation mentions its binder, and lowering the independent case to `map2` would delete `Recovery` outright; the wall is a library wall, not a language one).