### PR TITLE
backpass: pin the IO short-circuit, and record why ApplicativeDo cannot be inferred

### DIFF
--- a/crates/scarlet/tests/backpass_sequencing.rs
+++ b/crates/scarlet/tests/backpass_sequencing.rs
@@ -1,0 +1,149 @@
+//! A backpass over `result.then` short-circuits: when the bound step fails,
+//! nothing after it runs.
+//!
+//! This is the *statement-order* guarantee of `<-`, and it is load-bearing in
+//! the stdlib. Every one of the 19 backpass statements in
+//! `crates/scarlet_core/src/std` is over `result.then`/`result.map`, and 10 of
+//! them bind `_` — `_ <- result.then(flush(sock, pending))` in `http.scrl`,
+//! whose own comment says the pending bytes must reach the wire before the
+//! request body is awaited or the peer deadlocks. A lowering that ran the
+//! second step anyway would break those silently, because the binder they do
+//! not mention is exactly what makes them look independent.
+//!
+//! The programs are inline and run under a short bound rather than living in
+//! `tests/programs/`: `common::run_al` waits `CHILD_TIMEOUT_SECS`, and the
+//! failure this pins is a program that never ends. The discriminator is the
+//! exit code being *present* — a hung program and one that printed nothing
+//! are otherwise the same string.
+//!
+//! Watched failing: see T-211.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+mod common;
+use common::wait_or_kill;
+
+/// Long enough that a loaded machine does not fake a wedge, short enough that
+/// a real wedge is one slow red test rather than a two-minute one.
+const BOUND_SECS: u64 = 25;
+
+/// A failing first step whose continuation would not terminate if it ran.
+///
+/// `chunks` terminates for every `per >= 1` and never for `per == 0`, and `0`
+/// is what a lowering that manufactures a value to keep going would supply —
+/// the shape that made a quoted `"per"` hang instead of reporting a failure.
+const DIVERGENT_CONTINUATION: &str = r#"import scarlet/result
+
+type Step {
+	Boom
+}
+
+fn first_step() Result(Int, Step) {
+	Err(Boom)
+}
+
+fn chunks(n Int, per Int, acc Int) Int {
+	if n <= 0 {
+		acc
+	} else {
+		chunks(n - per, per, acc + 1)
+	}
+}
+
+fn pipeline() Result(Int, Step) {
+	per <- result.then(first_step())
+	println('SECOND STEP RAN')
+	Ok(chunks(8, per, 0))
+}
+
+match pipeline() {
+	Ok(v) -> println('ok ${v}')
+	Err(Boom) -> println('short-circuited')
+}
+println('done')
+"#;
+
+/// Two consecutive `_ <-` steps, neither mentioning the other's binder — the
+/// `http.scrl` shape. The second writes before it fails, so running it after
+/// the first failed is visible in stdout without needing a timeout.
+const TWO_INDEPENDENT_WRITES: &str = r#"import scarlet/result
+
+type Step {
+	Boom
+}
+
+fn write(tag String) Result(Nil, Step) {
+	println('write ${tag}')
+	Err(Boom)
+}
+
+fn both() Result(Nil, Step) {
+	_ <- result.then(write('a'))
+	_ <- result.then(write('b'))
+	Ok(Nil)
+}
+
+match both() {
+	Ok(Nil) -> println('ok')
+	Err(Boom) -> println('short-circuited')
+}
+"#;
+
+/// Write `src` as a one-file program and run it, giving up after `BOUND_SECS`.
+/// Returns the exit code — `None` when the child had to be killed — and its
+/// combined streams.
+fn run_bounded(tag: &str, src: &str) -> (Option<i32>, String) {
+    let dir = PathBuf::from(env!("CARGO_TARGET_TMPDIR")).join(format!("backpass_{tag}"));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let entry = dir.join("main.scrl");
+    std::fs::write(&entry, src).expect("write program");
+    std::fs::write(dir.join("package.scrl"), "name = 'backpass_test'\n").expect("write package");
+
+    let child = Command::new(env!("CARGO_BIN_EXE_scarlet"))
+        .arg("run")
+        .arg(&entry)
+        .current_dir(&dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("run scarlet");
+    let out = wait_or_kill(child, BOUND_SECS);
+    (
+        out.status.code(),
+        format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        ),
+    )
+}
+
+#[test]
+fn failed_step_does_not_run_a_continuation_that_would_not_end() {
+    let (code, out) = run_bounded("divergent", DIVERGENT_CONTINUATION);
+    assert_eq!(
+        code,
+        Some(0),
+        "no exit code means the program was killed at {BOUND_SECS}s — the continuation ran \
+         against a value the failed step never produced\noutput:\n{out}"
+    );
+    assert!(
+        !out.contains("SECOND STEP RAN"),
+        "the continuation of a failed `result.then` ran\noutput:\n{out}"
+    );
+    assert_eq!(out, "short-circuited\ndone\n", "output:\n{out}");
+}
+
+#[test]
+fn a_second_independent_step_does_not_run_after_the_first_fails() {
+    let (code, out) = run_bounded("two_writes", TWO_INDEPENDENT_WRITES);
+    assert_eq!(code, Some(0), "output:\n{out}");
+    assert!(
+        !out.contains("write b"),
+        "the second `_ <-` step ran after the first failed — `_` is not mentioned by either \
+         continuation, which is what makes these two look independent\noutput:\n{out}"
+    );
+    assert_eq!(out, "write a\nshort-circuited\n", "output:\n{out}");
+}

--- a/crates/scarlet_syntax/src/desugar.rs
+++ b/crates/scarlet_syntax/src/desugar.rs
@@ -8,6 +8,17 @@
 //! — never by the formatter, which renders the statement as written. After
 //! this pass no [`Statement::Backpass`] remains anywhere in the tree, so
 //! inference and lowering never see one.
+//!
+//! The lowering is bind-shaped for every backpass, and it must stay that way
+//! here: whether a step's binder is used later is visible from the AST, but
+//! whether running the later step after this one failed is *wanted* is a
+//! property of the callee, and this pass runs before imports resolve. All 19
+//! backpasses in the stdlib are over `result.then`/`result.map`, and 10 bind
+//! `_` — so a syntactic "independent, therefore combine" rule would reorder
+//! exactly the `http.scrl` writes whose comments say the ordering is
+//! load-bearing.
+//! `crates/scarlet/tests/backpass_sequencing.rs` fails if that changes; T-211
+//! carries the argument.
 
 use crate::ast::*;
 


### PR DESCRIPTION
T-211 asked whether the compiler could lower an *independent* backpass to an applicative combine — which would give the decoder multi-error accumulation without manufacturing a value, and delete `#32`'s `Recovery`/`also` machinery outright. **The answer is no as scoped.** These two tests are what stops the next person trying it by syntax alone.

## Where it fails

The *independence* half is a free-variable walk and is available in `desugar.rs`. The *should we* half is not: `desugar_program` runs before `compile_module_body` resolves imports, so `decode` in `decode.take(…)` is an unbound identifier — module, local record, or shadowing variable, indistinguishable. No type, no resolution, no callee.

## Syntax cannot stand in, and it is not close

All **19** backpass statements in `crates/scarlet_core/src/std` are over `result.then`/`result.map`, and **ten bind `_`** — which a continuation can never mention, so the naive criterion calls every one of them independent. Those are the load-bearing ones:

- `http.scrl:380` — `_ <- result.then(flush(sock, pending))` before reading a body, with a comment three lines above saying anything pending must go out first *"or the client could sit waiting for those responses before it sends the body we are about to wait for."* Applicative lowering there is a **deadlock**, not a lost error.
- `http.scrl:409` then `:414` — consecutive, and the second's RHS does not mention the first's binder, so these are independent under the **correct** criterion too, not just the naive one. That pair awaits a request body without having sent the 100-continue.

So the rule is wrong on the majority, and wrong precisely where a comment says the ordering is the point. This is GHC's own reason `ApplicativeDo` is a per-module opt-in: `<*>` for an accumulating `Result` is not `ap`.

**Ruled out:** type-directed desugaring keyed on inference. The applicative and bind forms differ in call *arity*, so the choice precedes elaboration of the argument list — a program's meaning would depend on inference order.

## Plants, both watched

A monomorphic speculative `then` — the shape `#32`'s `also` has — **reproduces `#32`'s hang on master**, with no `decoder-api` build: `SECOND STEP RAN`, `left: None, right: Some(0)`, killed at 25s. Restored, it short-circuits.

The short-circuit arm prints `write a` **and** `write b` planted, `write a` alone restored.

The first attempt at that second plant was rejected by the *compiler* rather than failing its assertion, so it proved nothing and was redone. Reporting it because a plant that fails to build is not a watched failure.

## Gates

`fmt` 0 · `clippy` 0 · `gen-editor-syntax --check` 0 · `test --workspace` 0 — **43 binaries, 1266 passed**.

Baseline correction: measured on this worktree with only the new test moved aside, `7b63b50` is **42 binaries / 1264 passed**, so this is exactly +1 binary / +2 tests. The 1265 figure quoted elsewhere does not reproduce here and was not chased.

## Follow-ups

- **T-224** — the owner picks the decoder fallback knowingly: short-circuit and lose accumulation, or keep the `map2..map5` arity ceiling. Also notes `#32`'s `Found` type and its `one_of`/`fail` signature fixes should land on their own branch, since review finding 8 is that they are bundled with the unsound part.
- **T-226** — the sound mechanism, scoped and costed: a marker on the **callee's declaration**, resolution-based and order-independent, with an indirect callee falling back to bind. It must name three functions, not one, because `map2` combines the run while a `then`-shaped join is still needed for the run's tail. Not prototyped; the unverified risk is whether `Statement::Backpass` can survive to elaboration without a circularity.

Separable from `#32` in both directions — it touches nothing `decoder-api` touches.