### PR TITLE
flag_cluster: fix the three findings, and pin the mordant pack by rev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,19 @@ strip = false
 debug = true
 
 [workspace.metadata.dylint]
-libraries = [{ git = "https://github.com/scarletindustries/mordant" }]
+# Pinned to a rev. Unpinned, `cargo dylint` resolves whatever the remote's HEAD
+# is at the moment each machine last fetched, so the mordant gate silently
+# changes underneath a tree that did not move: `flag_cluster` landing on mordant
+# master turned this repo's CI red with no commit here at all. It also
+# accumulates one `~/.cargo/git/checkouts` directory per rev, which is how the
+# same documented command comes to run two different lint sets in two worktrees
+# minutes apart.
+#
+# Bumping is now a deliberate act, and a fix on mordant master does not reach
+# this repo until someone moves this line.
+#
+# **Changing this line rebuilds nothing.** With a library already built, moving
+# the rev and re-running `cargo dylint` loads the dylib already in
+# `target/dylint`, so the bump leaves every run using the old pack.
+# `rm -rf target/dylint` is what makes it take, once per worktree.
+libraries = [{ git = "https://github.com/scarletindustries/mordant", rev = "eba57c339ebdfc7f2ce9a814507e028db0d21867" }]

--- a/crates/scarlet/src/main.rs
+++ b/crates/scarlet/src/main.rs
@@ -86,21 +86,106 @@ struct RunArgs {
     args: Vec<String>,
 }
 
-#[derive(Args)]
+/// What `al fmt` does with each file it formatted.
+#[derive(Clone, Copy)]
+enum FileAction {
+    /// Rewrite the file, when formatting changed it.
+    WriteBack,
+    /// `--stdout`: print the formatted text and leave the file alone.
+    Print,
+    /// `--check`: name the files that need formatting and exit 1 if any do.
+    Check,
+}
+
+/// What `al fmt` was pointed at, and what to do with it.
+///
+/// The three flags that select these are mutually exclusive, so the parse
+/// boundary is the last place a combination of them can be expressed:
+/// [`FmtArgs::target`] is what `cmd_fmt` reads. `--stdin --stdout` used to
+/// parse and then silently ignore `--stdout`, and `path` was only excluded
+/// alongside `--stdin` by a clap attribute; neither has a spelling here.
+enum FmtTarget {
+    /// `--stdin`: format stdin and print the result. Takes no path.
+    Stdin,
+    /// Walk `path` (default `.`) for `.scrl` files and apply `action` to each.
+    Files {
+        path: Option<String>,
+        action: FileAction,
+    },
+}
+
 struct FmtArgs {
-    path: Option<String>,
-    /// Print formatted output instead of writing to files
-    #[arg(long)]
-    stdout: bool,
-    /// Read input from stdin instead of a file
-    #[arg(long, conflicts_with_all = ["check", "path"])]
-    stdin: bool,
-    /// Check if files are formatted (exit 1 if not)
-    #[arg(long, conflicts_with = "stdout")]
-    check: bool,
-    /// Print debug information about tokens
-    #[arg(long)]
+    target: FmtTarget,
+    /// `--debug`: dump the token stream of each input before formatting it.
     debug: bool,
+}
+
+/// Hand-written because `FmtArgs` holds [`FmtTarget`] rather than one bool per
+/// flag, which no `#[derive(Args)]` spelling produces. The `Command` this
+/// builds is what `--help` and `scarlet man` render, so each arg keeps its
+/// help text.
+impl clap::FromArgMatches for FmtArgs {
+    fn from_arg_matches(m: &clap::ArgMatches) -> Result<Self, clap::Error> {
+        let target = if m.get_flag("stdin") {
+            FmtTarget::Stdin
+        } else {
+            FmtTarget::Files {
+                path: m.get_one::<String>("path").cloned(),
+                action: if m.get_flag("check") {
+                    FileAction::Check
+                } else if m.get_flag("stdout") {
+                    FileAction::Print
+                } else {
+                    FileAction::WriteBack
+                },
+            }
+        };
+        Ok(FmtArgs {
+            target,
+            debug: m.get_flag("debug"),
+        })
+    }
+
+    fn update_from_arg_matches(&mut self, m: &clap::ArgMatches) -> Result<(), clap::Error> {
+        *self = Self::from_arg_matches(m)?;
+        Ok(())
+    }
+}
+
+impl Args for FmtArgs {
+    fn augment_args(cmd: clap::Command) -> clap::Command {
+        cmd.arg(clap::Arg::new("path").value_name("PATH").index(1))
+            .arg(
+                clap::Arg::new("stdout")
+                    .long("stdout")
+                    .help("Print formatted output instead of writing to files")
+                    .action(clap::ArgAction::SetTrue)
+                    .conflicts_with_all(["check", "stdin"]),
+            )
+            .arg(
+                clap::Arg::new("stdin")
+                    .long("stdin")
+                    .help("Read input from stdin instead of a file")
+                    .action(clap::ArgAction::SetTrue)
+                    .conflicts_with_all(["check", "path", "stdout"]),
+            )
+            .arg(
+                clap::Arg::new("check")
+                    .long("check")
+                    .help("Check if files are formatted (exit 1 if not)")
+                    .action(clap::ArgAction::SetTrue),
+            )
+            .arg(
+                clap::Arg::new("debug")
+                    .long("debug")
+                    .help("Print debug information about tokens")
+                    .action(clap::ArgAction::SetTrue),
+            )
+    }
+
+    fn augment_args_for_update(cmd: clap::Command) -> clap::Command {
+        Self::augment_args(cmd)
+    }
 }
 
 /// Resolve a diagnostic's module provenance to (path, text) so it renders
@@ -329,10 +414,10 @@ fn main() -> process::ExitCode {
         Some(Commands::Build { entrypoint }) => {
             eprintln!("warning: `al build` is deprecated; use `al fmt --stdout <file>`");
             cmd_fmt(FmtArgs {
-                path: Some(entrypoint),
-                stdout: true,
-                stdin: false,
-                check: false,
+                target: FmtTarget::Files {
+                    path: Some(entrypoint),
+                    action: FileAction::Print,
+                },
                 debug: false,
             });
         }
@@ -536,47 +621,53 @@ fn compile_one(
     }
 }
 
-fn cmd_fmt(args: FmtArgs) {
-    if args.stdin {
-        let mut content = String::new();
-        if let Err(e) = io::stdin().read_to_string(&mut content) {
-            die(format!("Error reading stdin: {e}"));
-        }
-        if args.debug {
-            dump_tokens(&content);
-        }
-        match formatter::format(&content) {
-            formatter::FormatResult::Formatted { output } => {
-                print!("{output}");
-                let _ = io::stdout().flush();
-            }
-            formatter::FormatResult::ParseFailed { errors } => {
-                for d in &errors {
-                    eprintln!("{}", render_fmt_diagnostic("stdin", d));
-                }
-                process::exit(1);
-            }
-            formatter::FormatResult::CommentsLost { comment } => {
-                // Pass the input through untouched so no comment is deleted.
-                eprintln!(
-                    "formatter bug: formatting would delete the comment `{comment}`; input left unchanged"
-                );
-                print!("{content}");
-                let _ = io::stdout().flush();
-                process::exit(1);
-            }
-            formatter::FormatResult::OutputInvalid { detail } => {
-                // Pass the input through so valid source is never replaced.
-                eprintln!("formatter bug: {detail}; input left unchanged");
-                print!("{content}");
-                let _ = io::stdout().flush();
-                process::exit(1);
-            }
-        }
-        return;
+/// `al fmt --stdin`: format stdin and print the result. Separate from the file
+/// walk because there is no file to write back to, check, or name in an error.
+fn fmt_stdin(debug: bool) {
+    let mut content = String::new();
+    if let Err(e) = io::stdin().read_to_string(&mut content) {
+        die(format!("Error reading stdin: {e}"));
     }
+    if debug {
+        dump_tokens(&content);
+    }
+    match formatter::format(&content) {
+        formatter::FormatResult::Formatted { output } => {
+            print!("{output}");
+            let _ = io::stdout().flush();
+        }
+        formatter::FormatResult::ParseFailed { errors } => {
+            for d in &errors {
+                eprintln!("{}", render_fmt_diagnostic("stdin", d));
+            }
+            process::exit(1);
+        }
+        formatter::FormatResult::CommentsLost { comment } => {
+            // Pass the input through untouched so no comment is deleted.
+            eprintln!(
+                "formatter bug: formatting would delete the comment `{comment}`; input left unchanged"
+            );
+            print!("{content}");
+            let _ = io::stdout().flush();
+            process::exit(1);
+        }
+        formatter::FormatResult::OutputInvalid { detail } => {
+            // Pass the input through so valid source is never replaced.
+            eprintln!("formatter bug: {detail}; input left unchanged");
+            print!("{content}");
+            let _ = io::stdout().flush();
+            process::exit(1);
+        }
+    }
+}
 
-    let path = args.path.as_deref().unwrap_or(".");
+fn cmd_fmt(args: FmtArgs) {
+    let (path, action) = match args.target {
+        FmtTarget::Stdin => return fmt_stdin(args.debug),
+        FmtTarget::Files { path, action } => (path, action),
+    };
+
+    let path = path.as_deref().unwrap_or(".");
 
     let files = find_scarlet_files(path).unwrap_or_else(|e| die(e));
 
@@ -626,20 +717,24 @@ fn cmd_fmt(args: FmtArgs) {
             }
             formatter::FormatResult::Formatted { output } => {
                 let changed = output != content;
-                if args.check {
-                    if changed {
-                        println!("{} needs formatting", file.display());
-                        needs_formatting = true;
+                match action {
+                    FileAction::Check => {
+                        if changed {
+                            println!("{} needs formatting", file.display());
+                            needs_formatting = true;
+                        }
                     }
-                } else if args.stdout {
-                    print!("{output}");
-                } else if changed {
-                    if let Err(e) = fs::write(file, &output) {
-                        eprintln!("Error writing {}: {e}", file.display());
-                        has_errors = true;
-                        continue;
+                    FileAction::Print => print!("{output}"),
+                    FileAction::WriteBack => {
+                        if changed {
+                            if let Err(e) = fs::write(file, &output) {
+                                eprintln!("Error writing {}: {e}", file.display());
+                                has_errors = true;
+                                continue;
+                            }
+                            println!("Formatted {}", file.display());
+                        }
                     }
-                    println!("Formatted {}", file.display());
                 }
             }
         }
@@ -649,7 +744,7 @@ fn cmd_fmt(args: FmtArgs) {
         process::exit(1);
     }
 
-    if args.check && needs_formatting {
+    if matches!(action, FileAction::Check) && needs_formatting {
         process::exit(1);
     }
 }

--- a/crates/scarlet_core/Cargo.toml
+++ b/crates/scarlet_core/Cargo.toml
@@ -8,6 +8,12 @@ edition = "2024"
 # the counter on through either crate.
 alloc-counter = ["scarlet_vm/alloc-counter"]
 
+# `cargo dylint` sets `--cfg dylint_lib="mordant"` and plain cargo does not, so
+# the `#[cfg_attr(dylint_lib = "mordant", ...)]` suppression on `Compiler` is an
+# unexpected cfg to every other build — and `clippy -- -D warnings` fails on it.
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(dylint_lib, values("mordant"))'] }
+
 [dependencies]
 scarlet_syntax = { path = "../scarlet_syntax" }
 scarlet_types = { path = "../scarlet_types" }

--- a/crates/scarlet_core/src/bytecode/compiler/mod.rs
+++ b/crates/scarlet_core/src/bytecode/compiler/mod.rs
@@ -396,6 +396,18 @@ struct ElabFrame {
     frame_closures: Vec<ClosureSite>,
 }
 
+// `flag_cluster` fires on the four bool fields below, and the answer is that
+// all 16 states are legal: there is no illegal combination for an enum to
+// name. They are knobs on four unrelated subsystems — pipeline truncation,
+// hover-fact collection, namespace scoping, and a marker for one transient
+// walk — and both corners are reachable. All unset is an ordinary `compile`;
+// all set is `IncrementalSession::new_from_source`, which builds a
+// `check_only` compiler, sets `collect_hover_facts`, then calls
+// `register_prelude`, which runs under `with_retained_namespaces`, inside
+// which `analyse_module` sets `walking_module_statements`. The mode bools in
+// this struct that did carry an invariant are already enums — see
+// [`UnusedBindings`] and [`ModuleScope`]; these four carry none between them.
+#[cfg_attr(dylint_lib = "mordant", allow(flag_cluster))]
 pub struct Compiler {
     // --- Codegen state ---
     pub(super) program: Program,

--- a/crates/scarlet_vm/src/vm/http.rs
+++ b/crates/scarlet_vm/src/vm/http.rs
@@ -211,8 +211,8 @@ fn parse_head_window(t: &H1, a: &mut ProcHeap, win: &ByteWindow, off: i64) -> Va
         t.head_flags.instantiate(
             a,
             &[
-                Value::bool(flags.conn_close),
-                Value::bool(flags.conn_keep_alive),
+                Value::bool(flags.conn.has_close()),
+                Value::bool(flags.conn.has_keep_alive()),
                 Value::bool(flags.expect_100_continue),
             ],
         )
@@ -230,14 +230,60 @@ fn parse_head_window(t: &H1, a: &mut ProcHeap, win: &ByteWindow, off: i64) -> Va
     )
 }
 
+/// Which of the two persistence options the head's `Connection` fields named.
+/// All four are observable: `Connection` is a token list that may also be
+/// repeated, so a peer can genuinely send both, and `Both` records that
+/// instead of resolving it. RFC 9112 §9.3 gives `close` precedence over
+/// `keep-alive`, and that decision stays in `scarlet/http/h1.should_close`.
+///
+/// One field rather than two bools because the pair is one header's token
+/// set: neither half is separately assignable, and the four cases are the
+/// four the parser can witness.
+#[derive(Default, Clone, Copy, PartialEq)]
+enum ConnTokens {
+    #[default]
+    Neither,
+    Close,
+    KeepAlive,
+    Both,
+}
+
+impl ConnTokens {
+    const fn new(close: bool, keep_alive: bool) -> Self {
+        match (close, keep_alive) {
+            (false, false) => Self::Neither,
+            (true, false) => Self::Close,
+            (false, true) => Self::KeepAlive,
+            (true, true) => Self::Both,
+        }
+    }
+
+    const fn has_close(self) -> bool {
+        matches!(self, Self::Close | Self::Both)
+    }
+
+    const fn has_keep_alive(self) -> bool {
+        matches!(self, Self::KeepAlive | Self::Both)
+    }
+
+    /// A repeated `Connection` field means the same list split across lines,
+    /// so the tokens accumulate. Union, never replacement: `close` on a later
+    /// field must not unsee `keep-alive` on an earlier one.
+    const fn union(self, other: Self) -> Self {
+        Self::new(
+            self.has_close() | other.has_close(),
+            self.has_keep_alive() | other.has_keep_alive(),
+        )
+    }
+}
+
 /// The `Connection`/`Expect` token-list answers an HTTP/1.1 server needs from
 /// every request head, recorded by `parse_header_block` while it already has
 /// each field's trimmed name and value in hand. Raw findings, not decisions:
 /// precedence lives in `scarlet/http/h1.should_close`.
 #[derive(Default, Clone, Copy, PartialEq)]
 struct HeadFlags {
-    conn_close: bool,
-    conn_keep_alive: bool,
+    conn: ConnTokens,
     expect_100_continue: bool,
 }
 
@@ -331,8 +377,10 @@ fn parse_header_block(
         let name_bytes = &bytes[pos..colon];
         if name_bytes.eq_ignore_ascii_case(b"connection") {
             let value_bytes = &bytes[vstart..vend];
-            flags.conn_close |= has_token(value_bytes, b"close");
-            flags.conn_keep_alive |= has_token(value_bytes, b"keep-alive");
+            flags.conn = flags.conn.union(ConnTokens::new(
+                has_token(value_bytes, b"close"),
+                has_token(value_bytes, b"keep-alive"),
+            ));
         } else if name_bytes.eq_ignore_ascii_case(b"expect") {
             flags.expect_100_continue |= has_token(&bytes[vstart..vend], b"100-continue");
         }


### PR DESCRIPTION
`language` CI went red with **no commit in this repo**. `Cargo.toml` pinned the mordant pack by git URL with **no rev**, so it tracked mordant master — and `mordant#4` put `flag_cluster` there.

Three findings, three different right answers. **`-D warnings` aborts dylint at the first failing crate**, so the first was masking the other two: neither had ever been *seen* until it was fixed.

## The threshold is 3 bools, not 2

`flag_cluster.rs` reads `config.flag_cluster_min_bools.max(2)`, and `MordantConfig` defaults it to **3**; the `.max(2)` floor only applies to a workspace with no `dylint.toml` at all. `language` has one.

That is load-bearing: a two-of-four collapse on `Compiler` would have **cleared the lint without fixing anything**, and it is why `FmtArgs` is fixed by collapsing three flags and leaving one.

## `vm::http::HeadFlags` — 8 representable, 8 observable, 6 distinct

`Connection` is a token list *and* may be repeated, so `close, keep-alive` is a real wire state — but `(close, keep_alive)` and `(close, ¬keep_alive)` behave identically everywhere, so only 3 of the 4 are distinct.

Modelled the **observation**, named: `enum ConnTokens { Neither, Close, KeepAlive, Both }`, with accumulation across repeated fields an explicit `union` rather than two independent `|=`. Intent-modelling gives 6 states but changes the record's arity, needs three new `AbiSlot`s behind a new **public** `Persistence` type in `h1.scrl`, and reverses a decision the code states twice ("raw findings, not decisions") — a stdlib API change riding on a CI-unbreak.

**The RFC pointer in the ticket was off by a subsection**: §9.1 is *Establishment* and says nothing about tokens; the opinion is §9.3 *Persistence*, which `h1.scrl` already cited correctly at `should_close`.

## `bytecode::compiler::Compiler` — 2^4 = 16 → 16, argued suppression

**No state dropped, because none is illegal.** Every write site walked: `check_only` is construction-only, `collect_hover_facts` is a post-construction latch, `retain_namespaces` is scoped by `with_retained_namespaces`, `walking_module_statements` is `mem::replace`-scoped. No pair is exclusive.

And the all-true corner has a witness the ticket lacked: `IncrementalSession::new_from_source` → `new_compiler(None, true)`, sets `collect_hover_facts`, then `register_prelude` runs under `with_retained_namespaces`, inside which `analyse_module` sets `walking_module_statements`. **All four at once.** All-false is an ordinary `compile`.

The argument lives **in the code above the attribute**, not in a baseline entry, so `MORDANT_BASELINE_WRITE=1` cannot eat it. Supporting evidence: this struct's mode bools that *did* carry an invariant are already enums (`UnusedBindings`, `ModuleScope`) — the file's owners drew this line already, and these four sit on the other side of it.

## `FmtArgs` — 2^4 = 16 → 8, and the lint was pointing at a live defect

`--stdin --stdout` **parsed**, and `cmd_fmt`'s `if args.stdin` branch returned before ever reading `args.stdout` — the flag was silently ignored. `path` was excluded from `--stdin` by a clap attribute, not by the type.

clap's `conflicts_with` already excluded 6 of 16 at parse time; of the remaining 10, `(stdout, stdin)` in both `debug` settings behaved identically to `stdin` alone. So **8 were meaningfully distinct** — 4 output modes × 2 `debug` — and the type now represents exactly those.

`FmtTarget` is `Stdin` or `Files { path, action }`, so `path` lives only in the arm where it is legal. `derive(Args)` cannot produce this, so `Args`/`FromArgMatches` are hand-written — the `Command` they build is what `--help` and `clap_mangen` render, and every flag keeps its text.

**Behaviour change worth your judgement:** `--stdin --stdout` now exits 2 with `the argument '--stdin' cannot be used with '--stdout'` rather than being accepted and ignored. Previously accepted; never did anything.

## The pin

`rev = "eba57c33..."`, verified it took — the run's `DYLINT_METADATA` names that rev and the checkout appeared. Carried over from Scarlet's pin block, including that `rm -rf target/dylint` is what makes a bump take. **Deliberately not carried:** Scarlet's sentence about `xtask/src/check/mordant.rs` catching that staleness — `language` has no such gate, so it is a manual step here.

**The pin is now something somebody must move.** `t195-on-master` (`264bc0d`) is already waiting on the other side of it.

## Also required, and measured rather than predicted

`scarlet_core` gains `[lints.rust]` for `unexpected_cfgs`: `cargo dylint` sets `--cfg dylint_lib="mordant"` and plain cargo does not, so the `cfg_attr` made `clippy -- -D warnings` fail. A `[workspace.lints]` table would scale better but touches every manifest.

## Plants

Suppression removed → rc=1 naming `Compiler` at `mod.rs:411`. `main.rs` reverted → rc=1 naming `FmtArgs` at `main.rs:90`. Old struct literal → `E0560`, four fields. Old `HeadFlags` field spelling → `E0609`, *"available fields are: `conn`, `expect_100_continue`"*.

Every dylint run with `rm -rf target/dylint`, a `touch`, and a `.rc` deleted immediately before — one earlier read on this branch showed **stale `rc=0` files from a previous run** and was discarded (T-83).

## Gates

`fmt` 0 · `clippy -D warnings` 0 · `test --workspace` 0 (**43 binaries / 1303 passed**) · `gen-editor-syntax` 0 · `SCARLET_GC_STRESS=1` 0 · **`cargo dylint --all` 0**.

**No suppression in the tree lacks an argument.** The only one is `Compiler`'s, and its argument is the eleven lines above it.