### PR TITLE
prelude: bind Map late, because capture runs before its module loads

### DIFF
--- a/crates/scarlet_core/src/bytecode/compiler/mod.rs
+++ b/crates/scarlet_core/src/bytecode/compiler/mod.rs
@@ -2950,7 +2950,32 @@ impl Compiler {
             self.module_table.record_dependent(&imp, &key);
         }
         self.module_table.record_dependent(&key, &importer);
+        self.bind_late_prelude(&key);
         Some((canon, key))
+    }
+
+    /// Bind any late prelude type `key` defines (see `prelude_bindings`'s
+    /// `late_types`), which `PreludeBindings::capture` could not: it runs
+    /// before any stdlib module loads.
+    ///
+    /// Only the from-source path needs this. A statically seeded compiler gets
+    /// the binding already filled, because `seed_static` clones the baked
+    /// `PRELUDE` — so the `get_or_hydrate` exit above deliberately does *not*
+    /// call this. Repairing the binding there would hide a static stdlib built
+    /// without it; `precompile`'s tests are what hold that end.
+    fn bind_late_prelude(&mut self, key: &ModuleKey) {
+        let Compiler {
+            prelude,
+            module_table,
+            ..
+        } = self;
+        let Some(iface) = module_table.get(key) else {
+            return;
+        };
+        prelude.bind_late(key.as_str(), |name| {
+            let ti = &iface.types.get(name)?.info;
+            Some((ti.id, ti.arity()))
+        });
     }
 
     /// Run `f` with [`Self::retain_namespaces`] set: module compiles inside it

--- a/crates/scarlet_core/src/bytecode/prelude.rs
+++ b/crates/scarlet_core/src/bytecode/prelude.rs
@@ -53,3 +53,50 @@ impl Compiler {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::bytecode::compiler::new_compiler;
+    use crate::span::Span;
+
+    /// The from-source compile path: `capture` cannot see `Map`, so the binding
+    /// must arrive when `scarlet/map` loads. Without the `load_module` hook
+    /// this reads unbound and the descriptor builder cannot tell `Map(k, v)`
+    /// from any other opaque `Con`.
+    #[test]
+    fn map_binds_when_its_module_loads() {
+        let mut c = new_compiler(None, false);
+        c.register_prelude();
+        assert!(
+            !c.prelude_bindings().map().is_bound(),
+            "nothing has imported scarlet/map yet"
+        );
+
+        let path = crate::ast::ImportPath::canonical(vec!["scarlet".into(), "map".into()]);
+        c.with_retained_namespaces(|c| c.load_module(&path, Span::DUMMY));
+
+        let map = c.prelude_bindings().map();
+        assert!(
+            map.is_bound(),
+            "scarlet/map loaded but Map is still unbound"
+        );
+        assert_eq!(map.name, "Map");
+    }
+
+    /// Reaching `Map` only through a module whose signature mentions it
+    /// (`os.env() Map(String, String)`) must bind it too — that import is the
+    /// case a hook on the direct import alone would miss.
+    #[test]
+    fn map_binds_through_a_transitive_import() {
+        let mut c = new_compiler(None, false);
+        c.register_prelude();
+
+        let path = crate::ast::ImportPath::canonical(vec!["scarlet".into(), "os".into()]);
+        c.with_retained_namespaces(|c| c.load_module(&path, Span::DUMMY));
+
+        assert!(
+            c.prelude_bindings().map().is_bound(),
+            "scarlet/os imports scarlet/map.{{Map}}, so Map must be bound"
+        );
+    }
+}

--- a/crates/scarlet_core/src/bytecode/prelude_bindings.rs
+++ b/crates/scarlet_core/src/bytecode/prelude_bindings.rs
@@ -13,6 +13,7 @@ pub mod names {
     pub use crate::type_def::prim_names::{ARRAY, FLOAT, INT, STRING};
     pub(crate) const BOOL: &str = "Bool";
     pub(crate) const BINARY: &str = "Binary";
+    pub(crate) const MAP: &str = "Map";
     pub(crate) const NIL: &str = "Nil";
     pub(crate) const OPTION: &str = "Option";
     pub(crate) const RESULT: &str = "Result";
@@ -45,6 +46,13 @@ impl TypeRef {
     #[inline]
     pub(crate) fn is(&self, id: TypeId) -> bool {
         id != TypeId::NONE && id == self.id
+    }
+
+    /// Whether this binding has been resolved to a real type. A late binding
+    /// reads `false` until its defining module loads.
+    #[inline]
+    pub(crate) fn is_bound(&self) -> bool {
+        self.id != TypeId::NONE
     }
 }
 
@@ -145,11 +153,13 @@ impl std::fmt::Display for PreludeCaptureError {
 macro_rules! prelude_bindings {
     (
         types: [ $( $tf:ident = ($tn:ident, $ta:literal) ),* $(,)? ],
+        late_types: [ $( $lf:ident = ($ln:ident, $lm:expr, $la:literal) ),* $(,)? ],
         ctors: [ $( $cf:ident = ($cn:ident, $of:ident, $ar:literal) ),* $(,)? ],
     ) => {
         #[derive(Debug, Clone)]
         pub struct PreludeBindings {
             $( $tf: TypeRef, )*
+            $( $lf: TypeRef, )*
             $( $cf: CtorRef, )*
         }
 
@@ -157,6 +167,7 @@ macro_rules! prelude_bindings {
             fn default() -> Self {
                 PreludeBindings {
                     $( $tf: TypeRef::pending(names::$tn), )*
+                    $( $lf: TypeRef::pending(names::$ln), )*
                     $( $cf: CtorRef::ZERO, )*
                 }
             }
@@ -166,6 +177,12 @@ macro_rules! prelude_bindings {
             /// Name/arity of every prelude type binding, for the tests below.
             #[cfg(test)]
             const TYPE_NAMES: &[(&str, usize)] = &[$( (names::$tn, $ta) ),*];
+
+            /// Each late binding as (module path, type name, arity), for the
+            /// tests below — so a new late type is covered without editing them.
+            #[cfg(test)]
+            const LATE_TYPES: &[(&str, &'static str, usize)] =
+                &[$( ($lm, names::$ln, $la) ),*];
 
             pub fn capture(env: &TypeEnv) -> Result<Self, PreludeCaptureError> {
                 let ty = |name: &'static str, expected: usize| -> Result<TypeRef, PreludeCaptureError> {
@@ -215,7 +232,34 @@ macro_rules! prelude_bindings {
                 Ok(PreludeBindings {
                     $( $cf: ctor(names::$cn, &$of, $ar)?, )*
                     $( $tf, )*
+                    // Late bindings stay pending here on purpose: their
+                    // defining module has not loaded yet. See `bind_late`.
+                    $( $lf: TypeRef::pending(names::$ln), )*
                 })
+            }
+
+            /// Record the id of a late-bound type, given the interface of the
+            /// module that defines it. `module` is the loaded module's key;
+            /// bindings for other modules are left alone, so this is safe to
+            /// call after every load.
+            ///
+            /// Identity comes from the defining module's own interface, never
+            /// a by-name lookup in the ambient env — a user type called `Map`
+            /// must not bind here.
+            pub(crate) fn bind_late(
+                &mut self,
+                module: &str,
+                lookup: impl Fn(&str) -> Option<(TypeId, usize)>,
+            ) {
+                $(
+                    if module == $lm && !self.$lf.is_bound() {
+                        if let Some((id, arity)) = lookup(names::$ln) {
+                            if arity == $la {
+                                self.$lf = TypeRef { id, name: names::$ln };
+                            }
+                        }
+                    }
+                )*
             }
 
             /// Nominal ids for the four structural primitives the inference
@@ -237,6 +281,12 @@ macro_rules! prelude_bindings {
             )*
             $(
                 #[inline]
+                pub const fn $lf(&self) -> TypeRef {
+                    self.$lf
+                }
+            )*
+            $(
+                #[inline]
                 pub const fn $cf(&self) -> CtorRef {
                     self.$cf
                 }
@@ -249,15 +299,16 @@ macro_rules! prelude_bindings {
             /// generated from the same list and cannot drift.
             #[doc(hidden)]
             #[allow(clippy::too_many_arguments)] // positional by design; see above
-            pub const fn baked($( $tf: TypeRef, )* $( $cf: CtorRef, )*) -> Self {
+            pub const fn baked($( $tf: TypeRef, )* $( $lf: TypeRef, )* $( $cf: CtorRef, )*) -> Self {
                 PreludeBindings {
                     $( $tf, )*
+                    $( $lf, )*
                     $( $cf, )*
                 }
             }
 
             pub fn type_fields(&self) -> impl Iterator<Item = (&'static str, TypeRef)> {
-                [$( (stringify!($tf), self.$tf) ),*].into_iter()
+                [$( (stringify!($tf), self.$tf) ),* $(, (stringify!($lf), self.$lf) )*].into_iter()
             }
             pub fn ctor_fields(&self) -> impl Iterator<Item = (&'static str, CtorRef)> {
                 [$( (stringify!($cf), self.$cf) ),*].into_iter()
@@ -302,6 +353,13 @@ prelude_bindings! {
         array = (ARRAY, 1), binary = (BINARY, 0), nil = (NIL, 0),
         option = (OPTION, 1), result = (RESULT, 2),
     ],
+    // Bodiless stdlib types the compiler must recognise by id, defined outside
+    // the prelude. `capture` cannot see them: it runs in `register_prelude`,
+    // before any stdlib module loads. Bound by `bind_late` when their module
+    // does load, which is also the first moment a value of the type can exist.
+    late_types: [
+        map = (MAP, "scarlet/map", 2),
+    ],
     ctors: [
         true_ = (TRUE, bool, 0),
         false_ = (FALSE, bool, 0),
@@ -342,6 +400,56 @@ mod tests {
             }
         }
         (env, bool_id)
+    }
+
+    /// Every prelude constructor at its declared shape, so `capture` reaches
+    /// the late-type question instead of failing on a missing one.
+    fn define_all_prelude_ctors(env: &mut crate::types::TypeEnv, bool_id: TypeId) {
+        let id = |env: &crate::types::TypeEnv, n: &str| {
+            #[allow(clippy::expect_used)]
+            env.lookup_type_info(n).expect("registered above").id
+        };
+        let (nil, option, result) = (
+            id(env, names::NIL),
+            id(env, names::OPTION),
+            id(env, names::RESULT),
+        );
+        for (name, type_id, variant_idx, arity) in [
+            (names::TRUE, bool_id, 0, 0),
+            (names::FALSE, bool_id, 1, 0),
+            (names::NIL, nil, 0, 0),
+            (names::SOME, option, 0, 1),
+            (names::NONE, option, 1, 0),
+            (names::OK, result, 0, 1),
+            (names::ERR, result, 1, 1),
+        ] {
+            define_ctor(env, name, type_id, variant_idx, arity);
+        }
+    }
+
+    fn define_ctor(
+        env: &mut crate::types::TypeEnv,
+        name: &str,
+        type_id: TypeId,
+        variant_idx: u16,
+        arity: u16,
+    ) {
+        env.define(
+            name,
+            Scheme {
+                quantified: ArenaSlice::EMPTY,
+                ty: Ty::NONE,
+                kind: ValueKind::Constructor {
+                    type_name: StrId(0),
+                    type_id,
+                    variant_idx,
+                    variant_name: StrId(0),
+                    arity,
+                    field_labels: ArenaSlice::EMPTY,
+                },
+                def: None,
+            },
+        );
     }
 
     fn define_true_ctor(env: &mut crate::types::TypeEnv, type_id: TypeId, arity: u16) {
@@ -420,6 +528,83 @@ mod tests {
             err.to_string(),
             "prelude: 'True' must be a 0-arity constructor of 'Bool'; \
              found a non-constructor binding"
+        );
+    }
+
+    /// Every late type names a module outside the prelude. One inside it would
+    /// be a plain `types:` entry, and `capture` would be the place to demand it.
+    #[test]
+    fn late_types_are_declared_outside_the_prelude() {
+        assert!(!PreludeBindings::LATE_TYPES.is_empty());
+        for (module, name, _) in PreludeBindings::LATE_TYPES {
+            assert_ne!(
+                *module, "scarlet",
+                "late type '{name}' is in the prelude; declare it under `types:`"
+            );
+        }
+    }
+
+    /// `capture` runs in `register_prelude`, before any stdlib module loads, so
+    /// a late type must be pending there rather than required. Declaring `Map`
+    /// under `types:` instead fails every compile with "prelude: type 'Map' is
+    /// required".
+    #[test]
+    fn capture_leaves_late_types_pending() {
+        let (mut env, bool_id) = env_with_prelude_types();
+        define_all_prelude_ctors(&mut env, bool_id);
+        #[allow(clippy::expect_used)]
+        let b = PreludeBindings::capture(&env).expect("prelude types and ctors are all present");
+        assert!(
+            !b.map().is_bound(),
+            "Map must not be bound by capture: scarlet/map has not loaded yet"
+        );
+        assert!(!b.map().is(TypeId::NONE), "an unbound ref matches nothing");
+    }
+
+    /// The defining module's interface is the identity. A user type also called
+    /// `Map`, in some other module, must not bind here.
+    #[test]
+    fn bind_late_takes_only_its_own_module() {
+        let mut b = PreludeBindings::default();
+        b.bind_late("some/user/module", |_| Some((TypeId(77), 2)));
+        assert!(!b.map().is_bound(), "another module's 'Map' must not bind");
+
+        b.bind_late("scarlet/map", |name| {
+            (name == names::MAP).then_some((TypeId(42), 2))
+        });
+        assert!(b.map().is(TypeId(42)));
+        assert_eq!(b.map().name, "Map");
+    }
+
+    /// A drifted arity is refused rather than bound, the same judgement
+    /// `capture` makes for a prelude type.
+    #[test]
+    fn bind_late_refuses_a_drifted_arity() {
+        let mut b = PreludeBindings::default();
+        b.bind_late("scarlet/map", |_| Some((TypeId(42), 1)));
+        assert!(!b.map().is_bound(), "Map(k, v) has arity 2, not 1");
+    }
+
+    /// Binding is idempotent: `load_module` calls it on every import, and the
+    /// first id must win rather than the last caller's.
+    #[test]
+    fn bind_late_does_not_rebind() {
+        let mut b = PreludeBindings::default();
+        b.bind_late("scarlet/map", |_| Some((TypeId(42), 2)));
+        b.bind_late("scarlet/map", |_| Some((TypeId(99), 2)));
+        assert!(b.map().is(TypeId(42)));
+    }
+
+    /// `build.rs` bakes `const PRELUDE` by walking `type_fields` and feeding
+    /// `baked` positionally, so a late field missing from the iterator ships a
+    /// static stdlib whose Map binding is silently absent.
+    #[test]
+    fn type_fields_carries_every_late_type() {
+        let b = PreludeBindings::default();
+        let names: Vec<_> = b.type_fields().map(|(n, _)| n).collect();
+        assert!(
+            names.contains(&"map"),
+            "type_fields is missing 'map': {names:?}"
         );
     }
 

--- a/crates/scarlet_core/src/precompile.rs
+++ b/crates/scarlet_core/src/precompile.rs
@@ -365,6 +365,18 @@ mod tests {
             "Some/None are distinct variants"
         );
 
+        // A late binding is filled by `load_module`, not by `capture`, so this
+        // is the arm that witnesses it: `all_modules` above loaded
+        // `scarlet/map`, and `build.rs` bakes whatever is here into the static
+        // stdlib the CLI and REPL start from.
+        assert!(
+            p.map().is_bound(),
+            "Map is unbound after the whole stdlib loaded; \
+             the static stdlib would ship without it"
+        );
+        assert_eq!(p.map().name, "Map");
+        assert_ne!(p.map().id, p.array().id, "Map/Array share a type id");
+
         // The first user module's ids must sit past every stdlib id.
         assert!(out.next_type_id.0 > 0, "next_type_id should be positive");
 


### PR DESCRIPTION
`T-330`, wire 2/15. **The ticket's premise was false and this documents why**, because the obvious fix is the one that breaks every Scarlet program.

The ticket asked to give `Map` "the same treatment `Bool`/`Binary` already get". Those are **prelude** types; `Map` is declared in `src/std/scarlet/map.scrl`. `PreludeBindings::capture` runs inside `register_prelude()`, **before** `stdlib::all_modules()` — in the normal path and in both compiles inside `precompile_stdlib()`.

**Measured rather than argued:** adding `map = (MAP, 2)` to the macro's `types:` list gives rc=101 and **24 tests red**, every one reading `prelude: type 'Map' is required`. Not a wrong type id — nothing compiles at all.

## The fix

A `late_types:` section on `prelude_bindings!`. Declared alongside the other bindings so `build.rs`'s `emit_prelude` bakes it through `type_fields()`, but left pending by `capture`. `Compiler::bind_late_prelude` fills it from **the defining module's own interface** — never a by-name environment lookup, so a user type called `Map` cannot bind itself into the prelude slot. Capture order is unchanged; the deferral is per-binding.

**Deliberately not hooked into `get_or_hydrate`.** `seed_static` clones the baked `PRELUDE`, so repairing the binding at that exit would mask a static stdlib built without it — the same failure class PR #39 found, where a `build.rs` plant passed every in-compiler test. `precompile.rs` carries an assertion for that end instead.

## Watched failing, both restored

1. **Remove the `load_module` hook** → 3 red: `map_binds_when_its_module_loads`, `map_binds_through_a_transitive_import`, and the precompile assertion *"Map is unbound after the whole stdlib loaded"*.
2. **Move `map` back into `types:`** → 6 red.

## What this achieves, stated precisely

**The naive spelling still compiles.** It is caught loudly by six tests; it is *not* made unrepresentable. Avoided, not impossible — saying so because the difference is the point.

## Gates

`fmt` 0 · `clippy --all-targets` 0 warnings (CI is `-D warnings`) · `test --workspace` 0 — 1323 passed, 0 failed. Base is master `67884ce`, so this is gated against the tree it merges into.

## Reviewer call wanted

`bind_late`'s arity check **silently declines** rather than erroring on drift — consistent with the binding being optional, but unlike `capture`, which raises `TypeArity`. If a future late type's arity changes you get an unbound ref and a wire refusal instead of a diagnostic. Worth settling before T-333 depends on it.